### PR TITLE
fix(deploy): serve built dist/ on Cloudflare + restore COEP/COOP

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,6 +1,8 @@
 name: Build and Deploy (Cloudflare Pages)
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       bump:
@@ -14,6 +16,10 @@ on:
           - major
   release:
     types: [published]
+
+# Opt into Node.js 24 for JS actions (Node 20 on runners is deprecated June 2026).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   deploy:
@@ -38,9 +44,12 @@ jobs:
             VERSION="${{ github.event.release.tag_name }}"
             echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
             echo "source=release" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "source=manual" >> "$GITHUB_OUTPUT"
             echo "bump=${{ inputs.bump || 'patch' }}" >> "$GITHUB_OUTPUT"
+          else
+            # push to main: deploy the current package.json version, no bump
+            echo "source=push" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Bump version (manual dispatch)
@@ -75,4 +84,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "3.90.0"
           command: pages deploy dist --project-name=journal --commit-dirty=true

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,13 @@
+# Cloudflare Pages / Netlify headers
+# Cross-origin isolation — required for SharedArrayBuffer, WebLLM (WASM threads)
+# and OPFS. Mirrors the dev/preview server headers in vite.config.ts.
+# NOTE: require-corp blocks cross-origin subresources that lack CORP/CORS.
+# External images are proxied via the service worker to satisfy this; if Google
+# Fonts ever break, switch require-corp -> credentialless (still enables SAB in Chrome).
+/*
+  Cross-Origin-Embedder-Policy: require-corp
+  Cross-Origin-Opener-Policy: same-origin
+
+# Hashed build assets are immutable — cache them aggressively.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Problem

`journal.cloudx.run` was serving the **repository source**, not the Vite `dist/` build. Reproduced against the live server:

| Probe | Result | Meaning |
|---|---|---|
| `GET /` | source `index.html` referencing `/src/main.tsx` | serving source, not built HTML |
| `GET /src/main.tsx` | `200`, `content-type: application/octet-stream` | raw `.tsx` is physically on the host |
| `GET /assets/index-*.js` | `200` but `text/html` | built bundle isn't there (SPA fallback) |

The browser refuses to execute an `application/octet-stream` module (`nosniff`), so the app never boots — matching the console error `Failed to load module script: ... MIME type "application/octet-stream"`.

**Two compounding causes:**
1. The Cloudflare Pages project auto-builds from Git with no build step / output dir = repo root → serves source verbatim.
2. The GitHub Actions deploy that *would* upload a correct `dist/` has been failing since the `CLOUDFLARE_API_TOKEN` lost permission (`Authentication error [code: 10000]`). Last successful deploy: 2026-04-20.

The "redirected response … redirect mode is not follow" SW errors are a downstream symptom of a stale service worker; they clear once the correct build deploys and the SW updates.

## Changes

- **`.github/workflows/deploy-cloudflare.yml`**: deploy on push to `main` (guarded so a normal push deploys the current `package.json` version without triggering the version-bump-and-push loop); pin `wranglerVersion: 3.90.0`; opt JS actions into Node 24.
- **`public/_headers`**: restore COEP `require-corp` + COOP `same-origin` (mirrors `vite.config.ts` dev/preview headers; required for WebLLM/OPFS/SharedArrayBuffer) + immutable caching for hashed `/assets/*`. Reverses the `dd764b3` "let the dashboard handle COEP" decision, which wasn't applying them.

## Required out-of-band (dashboard / secrets)

This PR makes the build/deploy correct, but it won't go live until:
1. Regenerate `CLOUDFLARE_API_TOKEN` with **Account → Cloudflare Pages → Edit** and update the repo secret (verify `CLOUDFLARE_ACCOUNT_ID`).
2. Disable the Pages Git-integration auto-build so it stops serving repo root (the Actions workflow becomes the only deploy path).

## Verification

- `npm run build` green (tsc -b + vite); built `index.html` references a hashed `/assets/index-*.js`, not `/src/main.tsx`.
- `dist/_headers` confirmed present after build.
- Workflow YAML validated.

Post-deploy:
```bash
curl -s https://journal.cloudx.run/ | grep -o 'src="/assets/index[^"]*"'
curl -sI https://journal.cloudx.run/assets/index-*.js | grep -i content-type   # expect application/javascript
curl -sI https://journal.cloudx.run/ | grep -i cross-origin                    # expect COEP/COOP
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)