### PR TITLE
fix(trash): address code-review findings (critical un-trash + share-link + resurrection bugs)

### DIFF
--- a/src/__tests__/sharePublicNote.test.ts
+++ b/src/__tests__/sharePublicNote.test.ts
@@ -71,6 +71,25 @@ describe('ShareProvider.getPublicNote', () => {
         expect(client.getHostIdentity()).toBe(IDENTITY);
     });
 
+    it('returns null for a trashed note (archivalStatus 2), even though its ACL is still Anonymous', async () => {
+        mockGetHeader.mockResolvedValue({
+            fileId: 'file-xyz',
+            fileMetadata: {
+                transitUpdated: 1700000000000,
+                appData: {
+                    userDate: 1690000000000,
+                    archivalStatus: 2,
+                    content: JSON.stringify({ title: 'Trashed Public Note', tags: [] }),
+                },
+            },
+        });
+
+        const note = await shareProvider.getPublicNote(IDENTITY, NOTE_ID);
+
+        expect(note).toBeNull();
+        expect(mockGetPayload).not.toHaveBeenCalled();
+    });
+
     it('returns null when the note does not exist (header null / 404)', async () => {
         mockGetHeader.mockResolvedValue(null);
 

--- a/src/__tests__/trashNote.test.ts
+++ b/src/__tests__/trashNote.test.ts
@@ -1,14 +1,21 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { DotYouClient } from '@homebase-id/js-lib/core';
 import { SecurityGroupType } from '@homebase-id/js-lib/core';
+import type { DocumentMetadata } from '@/types';
 
-const { mockGetHeader, mockReUpload } = vi.hoisted(() => ({
+const { mockGetHeader, mockPatchFile, mockUploadFile } = vi.hoisted(() => ({
     mockGetHeader: vi.fn(),
-    mockReUpload: vi.fn(),
+    mockPatchFile: vi.fn(),
+    mockUploadFile: vi.fn(),
 }));
 vi.mock('@homebase-id/js-lib/core', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@homebase-id/js-lib/core')>();
-    return { ...actual, getFileHeaderByUniqueId: mockGetHeader, reUploadFile: mockReUpload };
+    return {
+        ...actual,
+        getFileHeaderByUniqueId: mockGetHeader,
+        patchFile: mockPatchFile,
+        uploadFile: mockUploadFile,
+    };
 });
 
 import { NotesDriveProvider } from '@/lib/homebase/NotesDriveProvider';
@@ -19,6 +26,7 @@ const fakeClient = { getHostIdentity: () => 'me.dotyou.cloud' } as unknown as Do
 function ownerHeader() {
     return {
         fileId: 'file-1',
+        sharedSecretEncryptedKeyHeader: { encryptionVersion: 1, type: 'aes', iv: 'aXY=', encryptedAesKey: 'aXY=' },
         fileMetadata: {
             versionTag: 'v1',
             isEncrypted: true,
@@ -34,25 +42,37 @@ function ownerHeader() {
     };
 }
 
+const baseMeta: DocumentMetadata = {
+    title: 'My Note',
+    folderId: 'folder-7',
+    tags: [],
+    timestamps: { created: '2026-01-01T00:00:00.000Z', modified: '2026-01-01T00:00:00.000Z' },
+    excludeFromAI: false,
+};
+
 describe('NotesDriveProvider.setNoteArchivalStatus', () => {
     let provider: NotesDriveProvider;
     beforeEach(() => {
         vi.clearAllMocks();
-        mockReUpload.mockResolvedValue({ newVersionTag: 'v2' });
+        mockPatchFile.mockResolvedValue({ newVersionTag: 'v2' });
         provider = new NotesDriveProvider(fakeClient);
     });
 
-    it('marks a note as trashed (archivalStatus 2) while preserving content and encryption', async () => {
+    it('trashes a note (archivalStatus 2) via a header-only patch (no payload re-upload)', async () => {
         mockGetHeader.mockResolvedValue(ownerHeader());
 
         await provider.setNoteArchivalStatus(NOTE_ID, 2);
 
-        const metadata = mockReUpload.mock.calls[0][2];
+        expect(mockPatchFile).toHaveBeenCalledTimes(1);
+        const metadata = mockPatchFile.mock.calls[0][3];
+        const payloads = mockPatchFile.mock.calls[0][4];
         expect(metadata.appData.archivalStatus).toBe(2);
         expect(JSON.parse(metadata.appData.content).title).toBe('My Note');
         expect(metadata.appData.userDate).toBe(1690000000000);
         expect(metadata.isEncrypted).toBe(true);
         expect(metadata.accessControlList.requiredSecurityGroup).toBe(SecurityGroupType.Owner);
+        // header-only: nothing re-uploaded
+        expect(payloads ?? []).toHaveLength(0);
     });
 
     it('restores a note (archivalStatus 0)', async () => {
@@ -60,11 +80,10 @@ describe('NotesDriveProvider.setNoteArchivalStatus', () => {
 
         await provider.setNoteArchivalStatus(NOTE_ID, 0);
 
-        const metadata = mockReUpload.mock.calls[0][2];
-        expect(metadata.appData.archivalStatus).toBe(0);
+        expect(mockPatchFile.mock.calls[0][3].appData.archivalStatus).toBe(0);
     });
 
-    it('reads the header decrypted so re-stored content stays valid', async () => {
+    it('reads the header decrypted so the patched content stays valid', async () => {
         mockGetHeader.mockResolvedValue(ownerHeader());
 
         await provider.setNoteArchivalStatus(NOTE_ID, 2);
@@ -75,5 +94,29 @@ describe('NotesDriveProvider.setNoteArchivalStatus', () => {
             NOTE_ID,
             expect.objectContaining({ decrypt: true })
         );
+    });
+});
+
+describe('archivalStatus survives normal create/update (no silent un-trash)', () => {
+    let provider: NotesDriveProvider;
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUploadFile.mockResolvedValue({ file: { fileId: 'f' }, newVersionTag: 'v' });
+        mockPatchFile.mockResolvedValue({ newVersionTag: 'v2' });
+        provider = new NotesDriveProvider(fakeClient);
+    });
+
+    it('createNote carries archivalStatus into appData', async () => {
+        await provider.createNote(NOTE_ID, { ...baseMeta, archivalStatus: 2 });
+
+        const metadata = mockUploadFile.mock.calls[0][2];
+        expect(metadata.appData.archivalStatus).toBe(2);
+    });
+
+    it('updateNote carries archivalStatus into appData (editing a trashed note keeps it trashed)', async () => {
+        await provider.updateNote(NOTE_ID, 'file-1', 'v1', { ...baseMeta, archivalStatus: 2 });
+
+        const metadata = mockPatchFile.mock.calls[0][3];
+        expect(metadata.appData.archivalStatus).toBe(2);
     });
 });

--- a/src/components/layout/TrashView.tsx
+++ b/src/components/layout/TrashView.tsx
@@ -53,6 +53,7 @@ function TrashViewComponent({
               <li
                 key={note.docId}
                 className="flex items-start gap-2 px-3 py-3 border-b border-border/50"
+                style={{ contentVisibility: "auto", containIntrinsicSize: "auto 64px" }}
               >
                 <FileText className="h-4 w-4 mt-0.5 text-muted-foreground/60 shrink-0" />
                 <div className="min-w-0 flex-1">

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -33,6 +33,11 @@ interface NoteMutationContext {
     previousNotes: NoteListEntry[] | undefined;
 }
 
+interface TrashMutationContext {
+    previousNotes: NoteListEntry[] | undefined;
+    previousTrash: NoteListEntry[] | undefined;
+}
+
 interface UpdateMetadataParams {
     docId: string;
     metadata: DocumentMetadata;
@@ -140,14 +145,17 @@ export function useNotes() {
     const emptyTrashMutation = useMutation<void, Error, void, { previousTrash: NoteListEntry[] | undefined }>({
         mutationFn: async () => {
             const trashed = await getTrashedNotes();
-            for (const note of trashed) {
-                await deleteNoteRemote(note.docId);
-                await Promise.all([
-                    deleteSearchIndexEntry(note.docId),
-                    deleteDocumentUpdates(note.docId),
-                    deleteSyncRecord(note.docId),
-                ]);
-            }
+            // Delete all in parallel; one failure must not abort the rest.
+            await Promise.allSettled(
+                trashed.map(async (note) => {
+                    await deleteNoteRemote(note.docId);
+                    await Promise.all([
+                        deleteSearchIndexEntry(note.docId),
+                        deleteDocumentUpdates(note.docId),
+                        deleteSyncRecord(note.docId),
+                    ]);
+                })
+            );
         },
         onMutate: async () => {
             await queryClient.cancelQueries({ queryKey: trashedNotesQueryKey });
@@ -327,7 +335,7 @@ export function useNotes() {
     });
 
     // Soft delete — move a note to Trash (Homebase archivalStatus 2).
-    const trashNoteMutation = useMutation<void, Error, string, NoteMutationContext>({
+    const trashNoteMutation = useMutation<void, Error, string, TrashMutationContext>({
         mutationFn: async (docId: string) => {
             await setNoteArchivalStatusRemote(docId, 2);
             await setNoteArchivalStatusLocal(docId, 2);
@@ -335,15 +343,23 @@ export function useNotes() {
         onMutate: async (docId) => {
             await queryClient.cancelQueries({ queryKey: notesQueryKey });
             const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
+            const previousTrash = queryClient.getQueryData<NoteListEntry[]>(trashedNotesQueryKey);
+            // Optimistically move the note from the active list into the trash list.
+            const moved = previousNotes?.find((n) => n.docId === docId);
             queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) =>
                 old?.filter((n) => n.docId !== docId) || []
             );
-            return { previousNotes };
+            if (moved) {
+                queryClient.setQueryData<NoteListEntry[]>(trashedNotesQueryKey, (old) => [
+                    moved,
+                    ...(old || []).filter((n) => n.docId !== docId),
+                ]);
+            }
+            return { previousNotes, previousTrash };
         },
         onError: (_err, _vars, context) => {
-            if (context?.previousNotes) {
-                queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            }
+            if (context?.previousNotes) queryClient.setQueryData(notesQueryKey, context.previousNotes);
+            if (context?.previousTrash) queryClient.setQueryData(trashedNotesQueryKey, context.previousTrash);
         },
         onSettled: () => {
             queryClient.invalidateQueries({ queryKey: notesQueryKey });
@@ -352,12 +368,7 @@ export function useNotes() {
     });
 
     // Restore a note from Trash (archivalStatus 0).
-    const restoreNoteMutation = useMutation<
-        void,
-        Error,
-        string,
-        { previousTrash: NoteListEntry[] | undefined }
-    >({
+    const restoreNoteMutation = useMutation<void, Error, string, TrashMutationContext>({
         mutationFn: async (docId: string) => {
             await setNoteArchivalStatusRemote(docId, 0);
             await setNoteArchivalStatusLocal(docId, 0);
@@ -365,15 +376,23 @@ export function useNotes() {
         onMutate: async (docId) => {
             await queryClient.cancelQueries({ queryKey: trashedNotesQueryKey });
             const previousTrash = queryClient.getQueryData<NoteListEntry[]>(trashedNotesQueryKey);
+            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
+            // Optimistically move the note from the trash list back into the active list.
+            const moved = previousTrash?.find((n) => n.docId === docId);
             queryClient.setQueryData<NoteListEntry[]>(trashedNotesQueryKey, (old) =>
                 old?.filter((n) => n.docId !== docId) || []
             );
-            return { previousTrash };
+            if (moved) {
+                queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) => [
+                    moved,
+                    ...(old || []).filter((n) => n.docId !== docId),
+                ]);
+            }
+            return { previousNotes, previousTrash };
         },
         onError: (_err, _vars, context) => {
-            if (context?.previousTrash) {
-                queryClient.setQueryData(trashedNotesQueryKey, context.previousTrash);
-            }
+            if (context?.previousNotes) queryClient.setQueryData(notesQueryKey, context.previousNotes);
+            if (context?.previousTrash) queryClient.setQueryData(trashedNotesQueryKey, context.previousTrash);
         },
         onSettled: () => {
             queryClient.invalidateQueries({ queryKey: notesQueryKey });
@@ -413,7 +432,8 @@ export function useNotesByFolder(folderId: string | undefined) {
     return useQuery<NoteListEntry[]>({
         queryKey: [...notesQueryKey, 'folder', folderId],
         queryFn: () => getNotesForListByFolder(folderId!),
-        enabled: !!folderId,
+        // 'trash' and 'shared' are pseudo-folders with their own views — skip the query.
+        enabled: !!folderId && folderId !== 'trash' && folderId !== 'shared',
     });
 }
 

--- a/src/layouts/JournalLayout.tsx
+++ b/src/layouts/JournalLayout.tsx
@@ -20,7 +20,7 @@ import {
   useKeyboardShortcuts,
 } from "@/hooks";
 import { cn } from "@/lib/utils";
-import { useState, useEffect, useRef, lazy, Suspense, useMemo, Activity } from "react";
+import { useState, useEffect, useRef, lazy, Suspense, useMemo, useCallback, Activity } from "react";
 import { ChevronLeft, Minimize2, Maximize2 } from "lucide-react";
 import { Kbd } from "@/components/ui/kbd";
 import { Button } from "@/components/ui/button";
@@ -233,6 +233,25 @@ export default function JournalLayout() {
     useCollaborativeNotes();
   const { data: trashedNotes = [], isLoading: isTrashLoading } = useTrashedNotes();
 
+  // Trash actions — stable handlers with user-visible error feedback.
+  const handleRestoreFromTrash = useCallback(
+    (id: string) => {
+      restoreNote(id).catch(() => toast.error("Couldn't restore note"));
+    },
+    [restoreNote],
+  );
+  const handleDeleteForever = useCallback(
+    (id: string) => {
+      // Close any open tab first so the editor can't resurrect the note via a debounced save.
+      closeTab(id);
+      deleteNote(id).catch(() => toast.error("Couldn't delete note"));
+    },
+    [deleteNote, closeTab],
+  );
+  const handleEmptyTrash = useCallback(() => {
+    emptyTrash().catch(() => toast.error("Couldn't empty Trash"));
+  }, [emptyTrash]);
+
   const selectedTag = searchParams.get("tag");
   const { tags } = useTags();
   const { data: tagFilteredNotes } = useNotesByTag(selectedTag);
@@ -400,9 +419,9 @@ export default function JournalLayout() {
             <TrashView
               notes={trashedNotes}
               isLoading={isTrashLoading}
-              onRestore={(id) => { restoreNote(id).catch(() => {}); }}
-              onDeleteForever={(id) => { deleteNote(id).catch(() => {}); }}
-              onEmptyTrash={() => { emptyTrash().catch(() => {}); }}
+              onRestore={handleRestoreFromTrash}
+              onDeleteForever={handleDeleteForever}
+              onEmptyTrash={handleEmptyTrash}
               className="flex-1"
             />
           ) : (
@@ -445,7 +464,12 @@ export default function JournalLayout() {
               // Also close the tab if it's open
               closeTab(id);
 
-              await trashNote(id);
+              try {
+                await trashNote(id);
+              } catch {
+                toast.error("Couldn't move note to Trash");
+                return;
+              }
 
               // If the deleted note is the one currently open, navigate to next note or folder
               if (noteId === id) {

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -2,6 +2,18 @@ import { MAIN_FOLDER_ID } from '../homebase';
 import { getDatabase } from './pglite';
 import type { SearchIndexEntry, NoteListEntry, Folder, DocumentMetadata, SyncRecord, PendingImageUpload, SyncError, AdvancedSearchResult } from '@/types';
 
+// Notes with archivalStatus 2 (Homebase "Removed") live in the Trash — exclude them
+// from every active-note list. Single source of truth for the filter.
+const ACTIVE_NOTES_FILTER = `COALESCE((metadata->>'archivalStatus')::int, 0) <> 2`;
+
+type NoteListRow = { doc_id: string; title: string; preview: string; metadata: DocumentMetadata };
+const toNoteListEntry = (row: NoteListRow): NoteListEntry => ({
+    docId: row.doc_id,
+    title: row.title,
+    preview: row.preview || '',
+    metadata: row.metadata,
+});
+
 
 
 // Document Updates (Yjs blobs)
@@ -143,15 +155,10 @@ export async function getNotesForList(): Promise<NoteListEntry[]> {
                 LEFT(plain_text_content, 150) as preview,
                 metadata
          FROM search_index
-         WHERE COALESCE((metadata->>'archivalStatus')::int, 0) <> 2
+         WHERE ${ACTIVE_NOTES_FILTER}
          ORDER BY (metadata->'timestamps'->>'modified')::timestamp DESC NULLS LAST`
     );
-    return result.rows.map(row => ({
-        docId: row.doc_id,
-        title: row.title,
-        preview: row.preview || '',
-        metadata: row.metadata,
-    }));
+    return result.rows.map(toNoteListEntry);
 }
 
 /**
@@ -172,12 +179,7 @@ export async function getTrashedNotes(): Promise<NoteListEntry[]> {
          WHERE COALESCE((metadata->>'archivalStatus')::int, 0) = 2
          ORDER BY (metadata->'timestamps'->>'modified')::timestamp DESC NULLS LAST`
     );
-    return result.rows.map(row => ({
-        docId: row.doc_id,
-        title: row.title,
-        preview: row.preview || '',
-        metadata: row.metadata,
-    }));
+    return result.rows.map(toNoteListEntry);
 }
 
 export async function getDocumentsByFolder(folderId: string): Promise<SearchIndexEntry[]> {
@@ -190,7 +192,7 @@ export async function getDocumentsByFolder(folderId: string): Promise<SearchInde
     }>(
         `SELECT doc_id, title, plain_text_content, metadata FROM search_index 
      WHERE metadata->>'folderId' = $1
-       AND COALESCE((metadata->>'archivalStatus')::int, 0) <> 2
+       AND ${ACTIVE_NOTES_FILTER}
      ORDER BY (metadata->'timestamps'->>'modified')::timestamp DESC NULLS LAST`,
         [folderId]
     );
@@ -221,16 +223,11 @@ export async function getNotesForListByFolder(folderId: string): Promise<NoteLis
                 metadata
          FROM search_index
          WHERE metadata->>'folderId' = $1
-           AND COALESCE((metadata->>'archivalStatus')::int, 0) <> 2
+           AND ${ACTIVE_NOTES_FILTER}
          ORDER BY (metadata->'timestamps'->>'modified')::timestamp DESC NULLS LAST`,
         [folderId]
     );
-    return result.rows.map(row => ({
-        docId: row.doc_id,
-        title: row.title,
-        preview: row.preview || '',
-        metadata: row.metadata,
-    }));
+    return result.rows.map(toNoteListEntry);
 }
 
 export async function getCollaborativeNotesForList(): Promise<NoteListEntry[]> {
@@ -246,17 +243,12 @@ export async function getCollaborativeNotesForList(): Promise<NoteListEntry[]> {
                 metadata
          FROM search_index
          WHERE (metadata->>'isCollaborative')::boolean = true
-           AND COALESCE((metadata->>'archivalStatus')::int, 0) <> 2
+           AND ${ACTIVE_NOTES_FILTER}
          ORDER BY
             (metadata->>'isPinned')::boolean DESC NULLS LAST,
             (metadata->'timestamps'->>'modified')::timestamp DESC NULLS LAST`
     );
-    return result.rows.map(row => ({
-        docId: row.doc_id,
-        title: row.title,
-        preview: row.preview || '',
-        metadata: row.metadata,
-    }));
+    return result.rows.map(toNoteListEntry);
 }
 
 export async function deleteSearchIndexEntry(docId: string): Promise<void> {
@@ -1157,16 +1149,11 @@ export async function getNotesForListByTag(tag: string): Promise<NoteListEntry[]
                 metadata
          FROM search_index
          WHERE metadata->'tags' ? $1
-           AND COALESCE((metadata->>'archivalStatus')::int, 0) <> 2
+           AND ${ACTIVE_NOTES_FILTER}
          ORDER BY
             (metadata->>'isPinned')::boolean DESC NULLS LAST,
             updated_at DESC`,
         [tag]
     );
-    return result.rows.map(row => ({
-        docId: row.doc_id,
-        title: row.title,
-        preview: row.preview || '',
-        metadata: row.metadata,
-    }));
+    return result.rows.map(toNoteListEntry);
 }

--- a/src/lib/homebase/NotesDriveProvider.ts
+++ b/src/lib/homebase/NotesDriveProvider.ts
@@ -71,7 +71,6 @@ export class NotesDriveProvider {
         const response = await queryBatch(this.#dotYouClient, {
             targetDrive: JOURNAL_DRIVE,
             fileType: [JOURNAL_FILE_TYPE],
-            archivalStatus: [0, 2], // active + trashed, so the Trash view stays in sync
         }, {
             maxRecords: pageSize,
             cursorState: cursor,
@@ -293,6 +292,7 @@ export class NotesDriveProvider {
                 userDate: Date.now(),
                 tags: (metadata.tags || []).map(tag => toGuidId(tag)),
                 content: JSON.stringify(noteContent),
+                archivalStatus: metadata.archivalStatus ?? 0,
             },
             isEncrypted: options?.encrypt || true,
             accessControlList: {
@@ -401,6 +401,7 @@ export class NotesDriveProvider {
                 userDate: Date.now(),
                 tags: (metadata.tags || []).map(tag => toGuidId(tag)),
                 content: JSON.stringify(noteContent),
+                archivalStatus: metadata.archivalStatus ?? 0,
             },
             isEncrypted: true,
             accessControlList,
@@ -698,9 +699,9 @@ export class NotesDriveProvider {
 
         const uploadMetadata: UploadFileMetadata = {
             versionTag: existingHeader.fileMetadata.versionTag,
-            // Keep distribution on only for collaborative (Connected) notes.
+            // Match the note's creation default: only public (Anonymous) notes distribute.
             allowDistribution:
-                accessControlList.requiredSecurityGroup === SecurityGroupType.Connected,
+                accessControlList.requiredSecurityGroup === SecurityGroupType.Anonymous,
             appData: {
                 fileType: JOURNAL_FILE_TYPE,
                 dataType: JOURNAL_DATA_TYPE,
@@ -715,12 +716,22 @@ export class NotesDriveProvider {
             accessControlList,
         };
 
-        const instructionSet: UploadInstructionSet = {
-            storageOptions: { drive: JOURNAL_DRIVE, overwriteFileId: existingHeader.fileId },
-            transferIv: getRandom16ByteArray(),
+        // Header-only patch — flips archivalStatus without re-uploading payloads
+        // (unlike makeNotePublic/Private, this never changes payload encryption).
+        const updateInstructions: UpdateInstructionSet = {
+            locale: 'local',
+            file: { fileId: existingHeader.fileId, targetDrive: JOURNAL_DRIVE },
+            versionTag: existingHeader.fileMetadata.versionTag,
         };
 
-        const result = await reUploadFile(this.#dotYouClient, instructionSet, uploadMetadata, isEncrypted);
+        const result = await patchFile(
+            this.#dotYouClient,
+            existingHeader.sharedSecretEncryptedKeyHeader,
+            updateInstructions,
+            uploadMetadata,
+            [],
+            undefined
+        );
 
         if (!result) {
             throw new Error('Failed to update note archival status');

--- a/src/lib/providers/ShareProvider.ts
+++ b/src/lib/providers/ShareProvider.ts
@@ -61,6 +61,10 @@ export class ShareProvider {
 
         if (!header?.fileId) return null;
 
+        // A trashed note (archivalStatus 2) keeps its Anonymous ACL, so the guest
+        // fetch still succeeds — but a shared link must not serve a trashed note.
+        if (header.fileMetadata?.appData?.archivalStatus === 2) return null;
+
         // Title and other metadata live in appData.content (plaintext for public notes).
         const content = await getContentFromHeaderOrPayload<NoteFileContent>(
             client,


### PR DESCRIPTION
Follow-up to the merged **#38** — lands the code-review fixes that were not in that PR.

## 🔴 Critical correctness
- **Editing/syncing a trashed note no longer un-trashes it.** `createNote` and `updateNote` were omitting `archivalStatus` from appData, so any push of a trashed note reset it to active. Now carried through. (Also fixes create-then-trash-before-first-sync and version-conflict merges.)
- **Trashed public notes are no longer served via their `/share` link.** `ShareProvider.getPublicNote` now returns `null` when `archivalStatus === 2` (the Anonymous ACL persists while trashed).
- **"Delete forever" closes the open editor tab first** — otherwise the editor's debounced save re-`upsert`s and resurrects the just-deleted note.

## 🟡 Efficiency / consistency
- `setNoteArchivalStatus` → **header-only `patchFile`** (no image-payload re-upload on trash/restore). `makeNotePublic`/`makeNotePrivate` keep `reUploadFile` — they must re-encrypt payloads for anonymous access.
- `allowDistribution` on trash/restore matches the note's creation default.
- `emptyTrash` uses `Promise.allSettled` (one failure no longer aborts the rest).
- Trash/restore **optimistically move** the note between the active and trash caches (no badge/list flicker).
- **Toast feedback** on trash/restore/delete/empty failures (no more silent `.catch(()=>{})`).

## 🧹 Cleanup
- `ACTIVE_NOTES_FILTER` constant + `toNoteListEntry` mapper (DRY across 5 queries).
- `useNotesByFolder` skips the `trash`/`shared` pseudo-folders.
- `content-visibility` on TrashView rows; reverted the dead `queryNotes` change.

## Tests
- New regression tests: editing a trashed note keeps `archivalStatus`; a trashed public note is not served. **245 passing**, build clean.

Context: these were found by a multi-agent review of #38 and verified adversarially. Recommend merging promptly since #38 shipped the critical bugs to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
