### PR TITLE
feat(sync): progressive sync — live reads + local-first mutations

### DIFF
--- a/src/__tests__/live_queries.test.ts
+++ b/src/__tests__/live_queries.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Phase 0 spike for progressive sync: prove PGlite's `live` extension emits
+ * progressively as rows are written. Uses a direct in-memory PGlite with the
+ * live extension (the app wires the same extension through PGliteWorker).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import { live, type LiveNamespace } from '@electric-sql/pglite/live';
+
+type LiveDB = PGlite & { live: LiveNamespace };
+
+const ID1 = '20000000-0000-0000-0000-000000000001';
+const ID2 = '20000000-0000-0000-0000-000000000002';
+const ID3 = '20000000-0000-0000-0000-000000000003';
+
+const LIST_SQL =
+  `SELECT doc_id, title, metadata FROM search_index ORDER BY title ASC`;
+
+let db: LiveDB;
+
+async function insertNote(id: string, title: string, folderId = 'main') {
+  await db.query(
+    `INSERT INTO search_index (doc_id, title, plain_text_content, metadata)
+     VALUES ($1, $2, $3, $4)`,
+    [id, title, title, JSON.stringify({ title, folderId })]
+  );
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000) {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timed out waiting for live emission');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+beforeAll(async () => {
+  db = (await PGlite.create({ extensions: { live } })) as LiveDB;
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS search_index (
+      doc_id UUID PRIMARY KEY,
+      title TEXT NOT NULL DEFAULT 'Untitled',
+      plain_text_content TEXT DEFAULT '',
+      metadata JSONB NOT NULL DEFAULT '{}',
+      updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+});
+afterAll(async () => { await db.close(); });
+beforeEach(async () => { await db.exec(`DELETE FROM search_index;`); });
+
+describe('PGlite live.incrementalQuery — progressive-sync foundation', () => {
+  it('returns the initial result set on subscribe', async () => {
+    await insertNote(ID1, 'Alpha');
+    const lq = await db.live.incrementalQuery(LIST_SQL, [], 'doc_id');
+    expect(lq.initialResults.rows).toHaveLength(1);
+    await lq.unsubscribe();
+  });
+
+  it('emits progressively as rows are inserted one-by-one (the WhatsApp effect)', async () => {
+    const counts: number[] = [];
+    const lq = await db.live.incrementalQuery(LIST_SQL, [], 'doc_id', (res) =>
+      counts.push(res.rows.length)
+    );
+    expect(lq.initialResults.rows).toHaveLength(0);
+
+    await insertNote(ID1, 'Alpha');
+    await waitFor(() => counts.includes(1));
+    await insertNote(ID2, 'Bravo');
+    await waitFor(() => counts.includes(2));
+    await insertNote(ID3, 'Charlie');
+    await waitFor(() => counts.includes(3));
+
+    expect(counts.at(-1)).toBe(3); // cumulative state, not a diff
+    await lq.unsubscribe();
+  });
+
+  it('emits on update and on delete', async () => {
+    await insertNote(ID1, 'Alpha');
+    let last: Array<{ title: string }> = [];
+    const lq = await db.live.incrementalQuery<{ doc_id: string; title: string }>(
+      LIST_SQL,
+      [],
+      'doc_id',
+      (res) => { last = res.rows; }
+    );
+
+    await db.query(`UPDATE search_index SET title = $2 WHERE doc_id = $1`, [ID1, 'Renamed']);
+    await waitFor(() => last.some((r) => r.title === 'Renamed'));
+
+    await db.query(`DELETE FROM search_index WHERE doc_id = $1`, [ID1]);
+    await waitFor(() => last.length === 0);
+
+    await lq.unsubscribe();
+  });
+
+  it('preserves JSONB metadata and supports a folderId WHERE filter', async () => {
+    await insertNote(ID1, 'InMain', 'main');
+    await insertNote(ID2, 'InWork', 'work');
+
+    const counts: number[] = [];
+    const lq = await db.live.incrementalQuery<{ doc_id: string; metadata: { folderId: string } }>(
+      `SELECT doc_id, title, metadata FROM search_index WHERE metadata->>'folderId' = $1 ORDER BY title ASC`,
+      ['main'],
+      'doc_id',
+      (res) => counts.push(res.rows.length)
+    );
+    expect(lq.initialResults.rows).toHaveLength(1);
+    expect((lq.initialResults.rows[0].metadata as { folderId: string }).folderId).toBe('main');
+
+    await insertNote(ID3, 'AnotherMain', 'main');
+    await waitFor(() => counts.includes(2));
+
+    await lq.unsubscribe();
+  });
+
+  it('stops emitting after unsubscribe', async () => {
+    const counts: number[] = [];
+    const lq = await db.live.incrementalQuery(LIST_SQL, [], 'doc_id', (res) =>
+      counts.push(res.rows.length)
+    );
+    await insertNote(ID1, 'Alpha');
+    await waitFor(() => counts.length > 0);
+    const seen = counts.length;
+
+    await lq.unsubscribe();
+    await insertNote(ID2, 'Bravo');
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(counts.length).toBe(seen); // no further emissions after unsubscribe
+  });
+});

--- a/src/__tests__/progressive_sync.test.ts
+++ b/src/__tests__/progressive_sync.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Phase 1 progressive-sync integration: prove the real NOTE_LIST_SQL / FOLDERS_SQL
+ * constants (the ones the live-query hooks subscribe to) emit progressively and
+ * honour the active/archived/trashed filters when driven through PGlite's `live`
+ * extension. Uses a direct in-memory PGlite with the same schema the app wires
+ * through PGliteWorker.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import { live, type LiveNamespace } from '@electric-sql/pglite/live';
+import {
+  NOTE_LIST_SQL,
+  NOTE_ROW_KEY,
+  FOLDERS_SQL,
+  FOLDER_ROW_KEY,
+  toNoteListEntry,
+  type NoteListRow,
+} from '@/lib/db/queries';
+
+type LiveDB = PGlite & { live: LiveNamespace };
+
+const ID1 = '30000000-0000-0000-0000-000000000001';
+const ID2 = '30000000-0000-0000-0000-000000000002';
+const ID3 = '30000000-0000-0000-0000-000000000003';
+const FOLDER_A = '30000000-0000-0000-0000-0000000000aa';
+
+let db: LiveDB;
+
+/** Insert a note the way upsertSearchIndex does: metadata carries timestamps + archivalStatus. */
+async function insertNote(
+  id: string,
+  title: string,
+  opts: { folderId?: string; archivalStatus?: number; modified?: string; isPinned?: boolean } = {}
+) {
+  const metadata = {
+    title,
+    folderId: opts.folderId ?? 'main',
+    archivalStatus: opts.archivalStatus ?? 0,
+    isPinned: opts.isPinned ?? false,
+    timestamps: { created: '2026-01-01T00:00:00.000Z', modified: opts.modified ?? '2026-01-01T00:00:00.000Z' },
+  };
+  await db.query(
+    `INSERT INTO search_index (doc_id, title, plain_text_content, metadata)
+     VALUES ($1, $2, $3, $4)`,
+    [id, title, title, JSON.stringify(metadata)]
+  );
+}
+
+/** Mirror setNoteArchivalStatusLocal — flip archivalStatus, preserving other metadata. */
+async function setArchivalStatus(id: string, status: number) {
+  await db.query(
+    `UPDATE search_index
+     SET metadata = jsonb_set(metadata, '{archivalStatus}', to_jsonb($2::int)),
+         updated_at = CURRENT_TIMESTAMP
+     WHERE doc_id = $1`,
+    [id, status]
+  );
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000) {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timed out waiting for live emission');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+beforeAll(async () => {
+  db = (await PGlite.create({ extensions: { live } })) as LiveDB;
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS search_index (
+      doc_id UUID PRIMARY KEY,
+      title TEXT NOT NULL DEFAULT 'Untitled',
+      plain_text_content TEXT DEFAULT '',
+      metadata JSONB NOT NULL DEFAULT '{}',
+      updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS folders (
+      id UUID PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+});
+afterAll(async () => { await db.close(); });
+beforeEach(async () => { await db.exec(`DELETE FROM search_index; DELETE FROM folders;`); });
+
+describe('NOTE_LIST_SQL.active — progressive emission + active filter', () => {
+  it('streams notes in cumulatively as they are inserted (the WhatsApp effect)', async () => {
+    const counts: number[] = [];
+    const lq = await db.live.incrementalQuery<NoteListRow>(
+      NOTE_LIST_SQL.active, [], NOTE_ROW_KEY, (res) => counts.push(res.rows.length)
+    );
+    expect(lq.initialResults.rows).toHaveLength(0);
+
+    await insertNote(ID1, 'Alpha', { modified: '2026-01-01T00:00:01.000Z' });
+    await waitFor(() => counts.includes(1));
+    await insertNote(ID2, 'Bravo', { modified: '2026-01-01T00:00:02.000Z' });
+    await waitFor(() => counts.includes(2));
+
+    expect(counts.at(-1)).toBe(2);
+    await lq.unsubscribe();
+  });
+
+  it('excludes archived (1) and trashed (2) notes from the active list', async () => {
+    await insertNote(ID1, 'Active', { archivalStatus: 0 });
+    await insertNote(ID2, 'Archived', { archivalStatus: 1 });
+    await insertNote(ID3, 'Trashed', { archivalStatus: 2 });
+
+    const lq = await db.live.incrementalQuery<NoteListRow>(NOTE_LIST_SQL.active, [], NOTE_ROW_KEY);
+    const titles = lq.initialResults.rows.map((r) => r.title);
+    expect(titles).toEqual(['Active']);
+    await lq.unsubscribe();
+  });
+
+  it('maps rows to NoteListEntry shape consumers expect', async () => {
+    await insertNote(ID1, 'Mapped');
+    const lq = await db.live.incrementalQuery<NoteListRow>(NOTE_LIST_SQL.active, [], NOTE_ROW_KEY);
+    const entry = toNoteListEntry(lq.initialResults.rows[0]);
+    expect(entry).toMatchObject({ docId: ID1, title: 'Mapped' });
+    expect(entry.metadata.archivalStatus).toBe(0);
+    await lq.unsubscribe();
+  });
+});
+
+describe('trash / archive transitions move notes between live lists', () => {
+  it('trashing a note removes it from active and adds it to trashed', async () => {
+    await insertNote(ID1, 'ToTrash');
+
+    let active: NoteListRow[] = [];
+    let trashed: NoteListRow[] = [];
+    const activeLq = await db.live.incrementalQuery<NoteListRow>(
+      NOTE_LIST_SQL.active, [], NOTE_ROW_KEY, (res) => { active = res.rows; }
+    );
+    const trashLq = await db.live.incrementalQuery<NoteListRow>(
+      NOTE_LIST_SQL.trashed, [], NOTE_ROW_KEY, (res) => { trashed = res.rows; }
+    );
+    expect(activeLq.initialResults.rows).toHaveLength(1);
+    expect(trashLq.initialResults.rows).toHaveLength(0);
+
+    await setArchivalStatus(ID1, 2);
+    await waitFor(() => active.length === 0 && trashed.length === 1);
+
+    expect(trashed[0].title).toBe('ToTrash');
+    await activeLq.unsubscribe();
+    await trashLq.unsubscribe();
+  });
+
+  it('archiving then unarchiving round-trips between active and archived', async () => {
+    await insertNote(ID1, 'ToArchive');
+    let active: NoteListRow[] = [];
+    let archived: NoteListRow[] = [];
+    const activeLq = await db.live.incrementalQuery<NoteListRow>(
+      NOTE_LIST_SQL.active, [], NOTE_ROW_KEY, (res) => { active = res.rows; }
+    );
+    const archiveLq = await db.live.incrementalQuery<NoteListRow>(
+      NOTE_LIST_SQL.archived, [], NOTE_ROW_KEY, (res) => { archived = res.rows; }
+    );
+
+    await setArchivalStatus(ID1, 1);
+    await waitFor(() => active.length === 0 && archived.length === 1);
+
+    await setArchivalStatus(ID1, 0);
+    await waitFor(() => active.length === 1 && archived.length === 0);
+
+    await activeLq.unsubscribe();
+    await archiveLq.unsubscribe();
+  });
+});
+
+describe('NOTE_LIST_SQL.byFolder — folder-scoped live query', () => {
+  it('only emits notes for the requested folder', async () => {
+    await insertNote(ID1, 'InA', { folderId: FOLDER_A });
+    await insertNote(ID2, 'InMain', { folderId: 'main' });
+
+    let rows: NoteListRow[] = [];
+    const lq = await db.live.incrementalQuery<NoteListRow>(
+      NOTE_LIST_SQL.byFolder, [FOLDER_A], NOTE_ROW_KEY, (res) => { rows = res.rows; }
+    );
+    expect(lq.initialResults.rows.map((r) => r.title)).toEqual(['InA']);
+
+    await insertNote(ID3, 'AlsoInA', { folderId: FOLDER_A, modified: '2026-02-01T00:00:00.000Z' });
+    await waitFor(() => rows.length === 2);
+
+    await lq.unsubscribe();
+  });
+});
+
+describe('FOLDERS_SQL — folder list live query', () => {
+  it('emits on folder creation', async () => {
+    let rows: Array<{ id: string; name: string }> = [];
+    const lq = await db.live.incrementalQuery<{ id: string; name: string; created_at: Date }>(
+      FOLDERS_SQL, [], FOLDER_ROW_KEY, (res) => { rows = res.rows; }
+    );
+    expect(lq.initialResults.rows).toHaveLength(0);
+
+    await db.query(`INSERT INTO folders (id, name) VALUES ($1, $2)`, [FOLDER_A, 'Work']);
+    await waitFor(() => rows.length === 1);
+    expect(rows[0].name).toBe('Work');
+
+    await lq.unsubscribe();
+  });
+});

--- a/src/components/editor/EditorProvider.tsx
+++ b/src/components/editor/EditorProvider.tsx
@@ -9,10 +9,8 @@ import {
 import { useAISettings } from "@/hooks/useAISettings";
 import { useEditor, type Editor } from "@tiptap/react";
 import * as Y from "yjs";
-import { useQueryClient } from "@tanstack/react-query";
 import { PGliteProvider } from "@/lib/yjs";
 import { upsertSearchIndex, savePendingImageUpload } from "@/lib/db";
-import { notesQueryKey } from "@/hooks/useNotes";
 import type { DocumentMetadata } from "@/types";
 import { EditorContext } from "./EditorContext";
 import { useSyncService } from "@/hooks/useSyncService";
@@ -58,7 +56,6 @@ export function EditorProvider({
 }: EditorProviderProps) {
   const [yDoc] = useState(() => new Y.Doc());
   const [isLoading, setIsLoading] = useState(true);
-  const queryClient = useQueryClient();
 
   // Use refs for cleanup to avoid stale closure issues
   const providerRef = useRef<PGliteProvider | null>(null);
@@ -261,9 +258,6 @@ export function EditorProvider({
     null,
   );
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const invalidateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
 
   const updateSearchIndex = useCallback(
     (editorInstance: Editor, plainTextContent?: string) => {
@@ -313,25 +307,12 @@ export function EditorProvider({
     }, 2000);
   }, []);
 
-  // Debounced query invalidation for NoteList updates
-  const invalidateNotes = useCallback(() => {
-    if (invalidateTimeoutRef.current) {
-      clearTimeout(invalidateTimeoutRef.current);
-    }
-
-    invalidateTimeoutRef.current = setTimeout(() => {
-      queryClient.invalidateQueries({ queryKey: notesQueryKey });
-    }, 1000);
-  }, [queryClient]);
-
   // Clean up all timeouts on unmount
   useEffect(() => {
     return () => {
       if (searchIndexTimeoutRef.current)
         clearTimeout(searchIndexTimeoutRef.current);
       if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
-      if (invalidateTimeoutRef.current)
-        clearTimeout(invalidateTimeoutRef.current);
     };
   }, []);
 
@@ -357,8 +338,9 @@ export function EditorProvider({
 
       const plainText = editor.getText();
 
+      // upsertSearchIndex (above) writes to PGlite; the note list live query
+      // picks up the title/preview change with no manual invalidation.
       updateSearchIndex(editor, plainText);
-      invalidateNotes();
 
       if (providerRef.current) {
         debouncedSave(providerRef.current);
@@ -369,7 +351,7 @@ export function EditorProvider({
     return () => {
       editor.off("update", handleUpdate);
     };
-  }, [editor, isLoading, updateSearchIndex, invalidateNotes, debouncedSave]);
+  }, [editor, isLoading, updateSearchIndex, debouncedSave]);
 
   const value = {
     editor,

--- a/src/components/layout/NoteList.tsx
+++ b/src/components/layout/NoteList.tsx
@@ -28,8 +28,7 @@ import type { NoteListEntry } from "@/types";
 import { formatRelativeTime } from "@/lib/utils/index";
 import { PullToRefresh } from "@/components/ui/PullToRefresh";
 import { useSyncService } from "@/hooks/useSyncService";
-import { useQueryClient } from "@tanstack/react-query";
-import { notesQueryKey, useNotes } from "@/hooks/useNotes";
+import { useNotes } from "@/hooks/useNotes";
 import { getNoteGroup } from "@/helpers/dateGrouping";
 
 interface NoteListProps {
@@ -62,15 +61,14 @@ export default function NoteList({
     "modified",
   );
   const { sync } = useSyncService();
-  const queryClient = useQueryClient();
   const { togglePin } = useNotes();
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
     () => new Set(),
   );
 
   const handleRefresh = async () => {
+    // The note list is a live query — a sync pull surfaces new notes automatically.
     await sync();
-    await queryClient.invalidateQueries({ queryKey: notesQueryKey });
   };
 
   const toggleGroup = (group: string) => {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -32,8 +32,6 @@ import { cn } from "@/lib/utils";
 import type { Folder } from "@/types";
 import { PullToRefresh } from "@/components/ui/PullToRefresh";
 import { useSyncService } from "@/hooks/useSyncService";
-import { useQueryClient } from "@tanstack/react-query";
-import { foldersQueryKey } from "@/hooks/useFolders";
 import { OwnerImage } from "@/components/author/AuthorImage";
 
 interface SidebarProps {
@@ -81,11 +79,10 @@ export default function Sidebar({
   const [folderToDelete, setFolderToDelete] = useState<string | null>(null);
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
   const { sync } = useSyncService();
-  const queryClient = useQueryClient();
 
   const handleRefresh = async () => {
+    // The folder list is a live query — a sync pull surfaces new folders automatically.
     await sync();
-    await queryClient.invalidateQueries({ queryKey: foldersQueryKey });
   };
 
   return (

--- a/src/components/providers/SyncProvider.tsx
+++ b/src/components/providers/SyncProvider.tsx
@@ -21,8 +21,6 @@ import {
 } from "@/lib/db";
 import { STORAGE_KEY_LAST_SYNC } from "@/lib/homebase";
 import { SyncContext, type SyncContextType } from "@/hooks/useSyncService";
-import { notesQueryKey } from "@/hooks/useNotes";
-import { foldersQueryKey } from "@/hooks/useFolders";
 import { tagsQueryKey } from "@/hooks/useTags";
 import type { SyncProgress } from "@/types";
 import { useOnlineContext } from "@/hooks/useOnlineContext";
@@ -156,13 +154,10 @@ export function SyncProvider({ children }: { children: ReactNode }) {
 
       setSyncStatus("idle");
 
-      // Invalidate queries to refresh UI with pulled data
-      if (result.pulled.folders > 0 || result.pulled.notes > 0) {
-        await Promise.all([
-          queryClient.invalidateQueries({ queryKey: foldersQueryKey }),
-          queryClient.invalidateQueries({ queryKey: notesQueryKey }),
-          queryClient.invalidateQueries({ queryKey: tagsQueryKey }),
-        ]);
+      // Notes and folders are live queries — pulled writes surface automatically.
+      // Only the derived tag list still needs a manual refresh.
+      if (result.pulled.notes > 0) {
+        await queryClient.invalidateQueries({ queryKey: tagsQueryKey });
       }
 
       if (result.errors.length > 0) {

--- a/src/hooks/useFolders.ts
+++ b/src/hooks/useFolders.ts
@@ -1,48 +1,43 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import {
-    getAllFolders,
     createFolder,
     deleteFolder,
+    getDocumentsByFolder,
     upsertSyncRecord,
     deleteSyncRecord,
     deleteSearchIndexEntry,
     deleteDocumentUpdates,
+    FOLDERS_SQL,
+    FOLDER_ROW_KEY,
+    toFolder,
 } from '@/lib/db';
 import { getNewId } from '@/lib/utils';
-import type { Folder, NoteListEntry } from '@/types';
 import { MAIN_FOLDER_ID } from '@/lib/homebase';
-import { notesQueryKey } from './useNotes';
 import { useSyncService } from '@/hooks/useSyncService';
 import { formatGuidId } from '@homebase-id/js-lib/helpers';
+import { useLiveQuery } from './useLiveQuery';
 
-export const foldersQueryKey = ['folders'] as const;
-
-interface CreateFolderContext {
-    previousFolders: Folder[] | undefined;
-}
-
-interface DeleteFolderContext {
-    previousFolders: Folder[] | undefined;
-    previousNotes: NoteListEntry[] | undefined;
-}
+type FolderRow = { id: string; name: string; created_at: Date };
 
 /**
  * Combined hook for managing folders.
+ *
+ * The folder list is a PGlite live query; mutations are local-first (write to
+ * PGlite, which updates the UI via the live query, then reconcile remotely).
  */
 export function useFolders() {
-    const queryClient = useQueryClient();
     const { deleteFolderRemote } = useSyncService();
 
-    // --- Queries ---
+    // --- Query (live) ---
 
-    const query = useQuery<Folder[]>({
-        queryKey: foldersQueryKey,
-        queryFn: getAllFolders,
-    });
+    const { data: rows, isLoading } = useLiveQuery<FolderRow>(FOLDERS_SQL, [], FOLDER_ROW_KEY);
+    const folders = useMemo(() => rows.map(toFolder), [rows]);
+    const query = { data: folders, isLoading };
 
     // --- Mutations ---
 
-    const createFolderMutation = useMutation<void, Error, string, CreateFolderContext>({
+    const createFolderMutation = useMutation<void, Error, string>({
         mutationFn: async (name: string) => {
             const folderId = formatGuidId(getNewId());
             await createFolder(folderId, name.trim());
@@ -53,18 +48,11 @@ export function useFolders() {
                 syncStatus: 'pending',
             });
         },
-
-        onError: (_err, _vars, context) => {
-            if (context?.previousFolders) {
-                queryClient.setQueryData(foldersQueryKey, context.previousFolders);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: foldersQueryKey });
-        },
     });
 
-    const deleteFolderMutation = useMutation<void, Error, string, DeleteFolderContext>({
+    // Remote-first: deleting locally before a confirmed remote delete would let
+    // the orphaned remote folder/notes resurface on the next pull.
+    const deleteFolderMutation = useMutation<void, Error, string>({
         mutationFn: async (folderId: string) => {
             if (folderId === MAIN_FOLDER_ID) {
                 throw new Error('Cannot delete Main folder');
@@ -74,10 +62,7 @@ export function useFolders() {
             await deleteFolderRemote(folderId);
 
             // Delete all notes in the folder locally (matching remote deletion via deleteFilesByGroupId)
-            const notes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-            const notesInFolder = notes?.filter((n) => n.metadata.folderId === folderId) || [];
-
-            // Delete each note's data locally
+            const notesInFolder = await getDocumentsByFolder(folderId);
             await Promise.all(
                 notesInFolder.map((note) =>
                     Promise.all([
@@ -91,37 +76,6 @@ export function useFolders() {
             // Delete the folder itself
             await deleteFolder(folderId);
             await deleteSyncRecord(folderId);
-        },
-        onMutate: async (folderId) => {
-            await queryClient.cancelQueries({ queryKey: foldersQueryKey });
-            await queryClient.cancelQueries({ queryKey: notesQueryKey });
-
-            const previousFolders = queryClient.getQueryData<Folder[]>(foldersQueryKey);
-            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-
-            // Optimistically remove folder
-            queryClient.setQueryData<Folder[]>(foldersQueryKey, (old) =>
-                old?.filter((f) => f.id !== folderId) || []
-            );
-
-            // Optimistically remove notes in the folder
-            queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) =>
-                old?.filter((n) => n.metadata.folderId !== folderId) || []
-            );
-
-            return { previousFolders, previousNotes };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousFolders) {
-                queryClient.setQueryData(foldersQueryKey, context.previousFolders);
-            }
-            if (context?.previousNotes) {
-                queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: foldersQueryKey });
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
         },
     });
 

--- a/src/hooks/useJournalWebsocket.ts
+++ b/src/hooks/useJournalWebsocket.ts
@@ -1,10 +1,7 @@
 import { useCallback, useRef, useEffect } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import type { DotYouClient, TypedConnectionNotification, DeletedHomebaseFile, ClientFileNotification } from '@homebase-id/js-lib/core';
 import { drivesEqual } from '@homebase-id/js-lib/helpers';
 import { useWebsocketSubscriber } from './useWebsocketSubscriber';
-import { notesQueryKey } from './useNotes';
-import { foldersQueryKey } from './useFolders';
 import { toast } from 'sonner';
 import {
     JOURNAL_DRIVE,
@@ -33,7 +30,6 @@ interface UseJournalWebsocketOptions {
  * Notifications are batched by uniqueId and flushed after 700ms of inactivity.
  */
 export const useJournalWebsocket = ({ isEnabled, syncService, onReconnect }: UseJournalWebsocketOptions) => {
-    const queryClient = useQueryClient();
     const disconnectTimeRef = useRef<number | null>(null);
     // Queue is created once in an effect — not during render
     const queueRef = useRef<WebSocketProcessQueue | null>(null);
@@ -54,13 +50,10 @@ export const useJournalWebsocket = ({ isEnabled, syncService, onReconnect }: Use
                 const fileType = notification.header?.fileMetadata?.appData?.fileType;
                 if (fileType === JOURNAL_FILE_TYPE) {
                     await syncService.handleRemoteNote(notification.header);
-                    queryClient.invalidateQueries({ queryKey: notesQueryKey });
                 } else if (fileType === FOLDER_FILE_TYPE) {
                     await syncService.handleRemoteFolder(notification.header);
-                    queryClient.invalidateQueries({ queryKey: foldersQueryKey });
                 } else if (fileType === COLLABORATION_INVITE_FILE_TYPE) {
                     await syncService.handleInvitation(notification.header);
-                    queryClient.invalidateQueries({ queryKey: notesQueryKey });
                     const content = notification.header?.fileMetadata?.appData?.content;
                     if (content) {
                         try {
@@ -77,23 +70,20 @@ export const useJournalWebsocket = ({ isEnabled, syncService, onReconnect }: Use
                     await syncService.handleDeletedNote(
                         notification.header as unknown as DeletedHomebaseFile,
                     );
-                    queryClient.invalidateQueries({ queryKey: notesQueryKey });
                 } else if (fileType === FOLDER_FILE_TYPE) {
                     await syncService.handleDeletedFolder(
                         notification.header as unknown as DeletedHomebaseFile,
                     );
-                    queryClient.invalidateQueries({ queryKey: foldersQueryKey });
                 } else if (fileType === COLLABORATION_INVITE_FILE_TYPE) {
                     await syncService.handleDeletedInvitation(
                         notification.header as unknown as DeletedHomebaseFile,
                     );
-                    queryClient.invalidateQueries({ queryKey: notesQueryKey });
                 }
             }
         } catch (error) {
             console.error('[JournalWebsocket] Error processing queued notification:', error);
         }
-    }, [syncService, queryClient]);
+    }, [syncService]);
 
 
     const processNotificationRef = useRef(processNotification);

--- a/src/hooks/useLiveQuery.ts
+++ b/src/hooks/useLiveQuery.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, startTransition } from 'react';
+import { useEffect, useRef, useState, startTransition } from 'react';
 import { getLiveDatabase } from '@/lib/db/pglite';
 
 interface LiveEntry {
@@ -32,6 +32,19 @@ export function useLiveQuery<T>(
 ): { data: T[]; isLoading: boolean } {
   const cacheKey = `${rowKey}::${sql}::${JSON.stringify(params)}`;
 
+  // The subscription effect re-runs only when cacheKey/enabled change; the raw
+  // inputs are read through "latest" refs (cacheKey already encodes when they
+  // meaningfully change), keeping the dependency list honest without disabling
+  // exhaustive-deps. Refs are synced in an effect — never written during render.
+  const sqlRef = useRef(sql);
+  const paramsRef = useRef(params);
+  const rowKeyRef = useRef(rowKey);
+  useEffect(() => {
+    sqlRef.current = sql;
+    paramsRef.current = params;
+    rowKeyRef.current = rowKey;
+  }, [sql, params, rowKey]);
+
   const [data, setData] = useState<T[]>(() => {
     const e = enabled ? registry.get(cacheKey) : undefined;
     return e?.ready ? (e.rows as T[]) : [];
@@ -40,28 +53,27 @@ export function useLiveQuery<T>(
     () => enabled && !registry.get(cacheKey)?.ready,
   );
 
-  // When the query key changes for the SAME hook instance (e.g. switching folder
-  // or tag), reset to the new key's snapshot during render so the list never
-  // flashes the previous query's rows. (React's "adjust state on prop change"
-  // pattern — re-renders before paint, no stale frame.)
-  const [renderedKey, setRenderedKey] = useState(cacheKey);
-  if (renderedKey !== cacheKey) {
-    setRenderedKey(cacheKey);
+  // Reset to the new key's snapshot during render when the query key or the
+  // enabled flag changes, so switching folder/tag never flashes the previous
+  // query's rows. (React's adjust-state-on-change pattern — re-renders before
+  // paint, and keeps setState out of the effect body.)
+  const stateKey = `${cacheKey}::${enabled}`;
+  const [renderedKey, setRenderedKey] = useState(stateKey);
+  if (renderedKey !== stateKey) {
+    setRenderedKey(stateKey);
     const e = enabled ? registry.get(cacheKey) : undefined;
     setData(e?.ready ? (e.rows as T[]) : []);
     setIsLoading(enabled ? !e?.ready : false);
   }
 
   useEffect(() => {
-    if (!enabled) {
-      setData([]);
-      setIsLoading(false);
-      return;
-    }
+    if (!enabled) return;
+
     let active = true;
     const listener = (rows: unknown[]) => {
       if (!active) return;
-      // Sync emissions are non-urgent — keep user interactions responsive.
+      // Subscription callback (external store) — non-urgent, so keep user
+      // interactions responsive while sync emissions land.
       startTransition(() => {
         setData(rows as T[]);
         setIsLoading(false);
@@ -80,7 +92,10 @@ export function useLiveQuery<T>(
     const myEntry = entry;
 
     if (entry.ready) {
-      listener(entry.rows);
+      // Already-cached snapshot — deliver via a microtask so this stays out of
+      // the synchronous effect body (a re-render bails out if rows are unchanged).
+      const rows = entry.rows;
+      queueMicrotask(() => listener(rows));
     } else if (!entry.subscribing) {
       // First consumer (or a retry after a failed attempt) creates the shared
       // subscription. Gating on `subscribing` (not refs) lets a later mount
@@ -90,9 +105,9 @@ export function useLiveQuery<T>(
         try {
           const db = await getLiveDatabase();
           const lq = await db.live.incrementalQuery(
-            sql,
-            params as unknown[],
-            rowKey,
+            sqlRef.current,
+            paramsRef.current as unknown[],
+            rowKeyRef.current,
             (res) => {
               // Drop emissions for an entry that was discarded and replaced.
               if (registry.get(cacheKey) !== myEntry) return;
@@ -133,9 +148,6 @@ export function useLiveQuery<T>(
         void e.unsubscribe?.();
       }
     };
-    // cacheKey encodes rowKey+sql+params; depending on the raw (array) params would
-    // re-subscribe on every render (rerender-dependencies). cacheKey is the gate.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cacheKey, enabled]);
 
   return { data, isLoading };

--- a/src/hooks/useLiveQuery.ts
+++ b/src/hooks/useLiveQuery.ts
@@ -1,0 +1,109 @@
+import { useEffect, useState, startTransition } from 'react';
+import { getLiveDatabase } from '@/lib/db/pglite';
+
+interface LiveEntry {
+  refs: number;
+  rows: unknown[];
+  ready: boolean;
+  listeners: Set<(rows: unknown[]) => void>;
+  unsubscribe?: () => Promise<void>;
+}
+
+// Shared, ref-counted subscriptions keyed by (rowKey, sql, params). Multiple
+// components reading the same query share one PGlite live subscription.
+const registry = new Map<string, LiveEntry>();
+
+/**
+ * Subscribe to a PGlite live (incremental) query. PGlite is the reactive source:
+ * any write to the underlying table re-emits results, so the UI updates
+ * progressively (e.g. notes streaming in during sync) with no manual invalidation.
+ *
+ * @param sql     query text
+ * @param params  positional params (compared by value, not identity)
+ * @param rowKey  unique column used by incrementalQuery for row diffing (e.g. 'doc_id')
+ */
+export function useLiveQuery<T>(
+  sql: string,
+  params: ReadonlyArray<unknown>,
+  rowKey: string,
+): { data: T[]; isLoading: boolean } {
+  const cacheKey = `${rowKey}::${sql}::${JSON.stringify(params)}`;
+
+  const [data, setData] = useState<T[]>(() => {
+    const e = registry.get(cacheKey);
+    return e?.ready ? (e.rows as T[]) : [];
+  });
+  const [isLoading, setIsLoading] = useState<boolean>(() => !registry.get(cacheKey)?.ready);
+
+  useEffect(() => {
+    let active = true;
+    const listener = (rows: unknown[]) => {
+      if (!active) return;
+      // Sync emissions are non-urgent — keep user interactions responsive.
+      startTransition(() => {
+        setData(rows as T[]);
+        setIsLoading(false);
+      });
+    };
+
+    let entry = registry.get(cacheKey);
+    if (!entry) {
+      entry = { refs: 0, rows: [], ready: false, listeners: new Set() };
+      registry.set(cacheKey, entry);
+    }
+    entry.refs += 1;
+    entry.listeners.add(listener);
+
+    if (entry.ready) {
+      listener(entry.rows);
+    } else if (entry.refs === 1) {
+      // First consumer creates the shared subscription.
+      void (async () => {
+        try {
+          const db = await getLiveDatabase();
+          const lq = await db.live.incrementalQuery(
+            sql,
+            params as unknown[],
+            rowKey,
+            (res) => {
+              const e = registry.get(cacheKey);
+              if (!e) return;
+              e.rows = res.rows;
+              e.listeners.forEach((l) => l(res.rows));
+            },
+          );
+          const e = registry.get(cacheKey);
+          if (!e) {
+            // Every consumer unmounted before the subscription was ready.
+            await lq.unsubscribe();
+            return;
+          }
+          e.rows = lq.initialResults.rows;
+          e.unsubscribe = lq.unsubscribe;
+          e.ready = true;
+          e.listeners.forEach((l) => l(e.rows));
+        } catch (err) {
+          console.error('[useLiveQuery] subscription failed:', err);
+          registry.get(cacheKey)?.listeners.forEach((l) => l([]));
+        }
+      })();
+    }
+
+    return () => {
+      active = false;
+      const e = registry.get(cacheKey);
+      if (!e) return;
+      e.listeners.delete(listener);
+      e.refs -= 1;
+      if (e.refs <= 0) {
+        registry.delete(cacheKey);
+        void e.unsubscribe?.();
+      }
+    };
+    // cacheKey encodes rowKey+sql+params; depending on the raw (array) params would
+    // re-subscribe on every render (rerender-dependencies). cacheKey is the gate.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cacheKey]);
+
+  return { data, isLoading };
+}

--- a/src/hooks/useLiveQuery.ts
+++ b/src/hooks/useLiveQuery.ts
@@ -5,6 +5,7 @@ interface LiveEntry {
   refs: number;
   rows: unknown[];
   ready: boolean;
+  subscribing: boolean;
   listeners: Set<(rows: unknown[]) => void>;
   unsubscribe?: () => Promise<void>;
 }
@@ -21,6 +22,7 @@ const registry = new Map<string, LiveEntry>();
  * @param sql     query text
  * @param params  positional params (compared by value, not identity)
  * @param rowKey  unique column used by incrementalQuery for row diffing (e.g. 'doc_id')
+ * @param enabled when false, no subscription is created and the result is empty
  */
 export function useLiveQuery<T>(
   sql: string,
@@ -31,10 +33,24 @@ export function useLiveQuery<T>(
   const cacheKey = `${rowKey}::${sql}::${JSON.stringify(params)}`;
 
   const [data, setData] = useState<T[]>(() => {
-    const e = registry.get(cacheKey);
+    const e = enabled ? registry.get(cacheKey) : undefined;
     return e?.ready ? (e.rows as T[]) : [];
   });
-  const [isLoading, setIsLoading] = useState<boolean>(() => !registry.get(cacheKey)?.ready);
+  const [isLoading, setIsLoading] = useState<boolean>(
+    () => enabled && !registry.get(cacheKey)?.ready,
+  );
+
+  // When the query key changes for the SAME hook instance (e.g. switching folder
+  // or tag), reset to the new key's snapshot during render so the list never
+  // flashes the previous query's rows. (React's "adjust state on prop change"
+  // pattern — re-renders before paint, no stale frame.)
+  const [renderedKey, setRenderedKey] = useState(cacheKey);
+  if (renderedKey !== cacheKey) {
+    setRenderedKey(cacheKey);
+    const e = enabled ? registry.get(cacheKey) : undefined;
+    setData(e?.ready ? (e.rows as T[]) : []);
+    setIsLoading(enabled ? !e?.ready : false);
+  }
 
   useEffect(() => {
     if (!enabled) {
@@ -54,16 +70,22 @@ export function useLiveQuery<T>(
 
     let entry = registry.get(cacheKey);
     if (!entry) {
-      entry = { refs: 0, rows: [], ready: false, listeners: new Set() };
+      entry = { refs: 0, rows: [], ready: false, subscribing: false, listeners: new Set() };
       registry.set(cacheKey, entry);
     }
     entry.refs += 1;
     entry.listeners.add(listener);
+    // Capture the entry by identity so the async closure below always targets
+    // the entry it was created for — never a later generation that replaced it.
+    const myEntry = entry;
 
     if (entry.ready) {
       listener(entry.rows);
-    } else if (entry.refs === 1) {
-      // First consumer creates the shared subscription.
+    } else if (!entry.subscribing) {
+      // First consumer (or a retry after a failed attempt) creates the shared
+      // subscription. Gating on `subscribing` (not refs) lets a later mount
+      // re-attempt if creation failed, instead of wedging the entry forever.
+      entry.subscribing = true;
       void (async () => {
         try {
           const db = await getLiveDatabase();
@@ -72,25 +94,30 @@ export function useLiveQuery<T>(
             params as unknown[],
             rowKey,
             (res) => {
-              const e = registry.get(cacheKey);
-              if (!e) return;
-              e.rows = res.rows;
-              e.listeners.forEach((l) => l(res.rows));
+              // Drop emissions for an entry that was discarded and replaced.
+              if (registry.get(cacheKey) !== myEntry) return;
+              myEntry.rows = res.rows;
+              myEntry.listeners.forEach((l) => l(res.rows));
             },
           );
-          const e = registry.get(cacheKey);
-          if (!e) {
-            // Every consumer unmounted before the subscription was ready.
+          if (registry.get(cacheKey) !== myEntry) {
+            // Every consumer of this generation unmounted before the
+            // subscription resolved — tear the orphan down instead of leaking it.
             await lq.unsubscribe();
             return;
           }
-          e.rows = lq.initialResults.rows;
-          e.unsubscribe = lq.unsubscribe;
-          e.ready = true;
-          e.listeners.forEach((l) => l(e.rows));
+          myEntry.rows = lq.initialResults.rows;
+          myEntry.unsubscribe = lq.unsubscribe;
+          myEntry.ready = true;
+          myEntry.subscribing = false;
+          myEntry.listeners.forEach((l) => l(myEntry.rows));
         } catch (err) {
           console.error('[useLiveQuery] subscription failed:', err);
-          registry.get(cacheKey)?.listeners.forEach((l) => l([]));
+          // Clear the flag so a later mount can retry rather than stay wedged.
+          myEntry.subscribing = false;
+          if (registry.get(cacheKey) === myEntry) {
+            myEntry.listeners.forEach((l) => l([]));
+          }
         }
       })();
     }

--- a/src/hooks/useLiveQuery.ts
+++ b/src/hooks/useLiveQuery.ts
@@ -26,6 +26,7 @@ export function useLiveQuery<T>(
   sql: string,
   params: ReadonlyArray<unknown>,
   rowKey: string,
+  enabled: boolean = true,
 ): { data: T[]; isLoading: boolean } {
   const cacheKey = `${rowKey}::${sql}::${JSON.stringify(params)}`;
 
@@ -36,6 +37,11 @@ export function useLiveQuery<T>(
   const [isLoading, setIsLoading] = useState<boolean>(() => !registry.get(cacheKey)?.ready);
 
   useEffect(() => {
+    if (!enabled) {
+      setData([]);
+      setIsLoading(false);
+      return;
+    }
     let active = true;
     const listener = (rows: unknown[]) => {
       if (!active) return;
@@ -103,7 +109,7 @@ export function useLiveQuery<T>(
     // cacheKey encodes rowKey+sql+params; depending on the raw (array) params would
     // re-subscribe on every render (rerender-dependencies). cacheKey is the gate.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cacheKey]);
+  }, [cacheKey, enabled]);
 
   return { data, isLoading };
 }

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -74,7 +74,13 @@ export function useNotes() {
         try {
             await setNoteArchivalStatusRemote(docId, status);
         } catch (err) {
-            await setNoteArchivalStatusLocal(docId, prev);
+            // Only roll back if no concurrent transition has changed the status
+            // since we wrote it — otherwise we'd clobber that transition's result
+            // and leave local/remote divergent.
+            const current = (await getSearchIndexEntry(docId))?.metadata.archivalStatus ?? 0;
+            if (current === status) {
+                await setNoteArchivalStatusLocal(docId, prev);
+            }
             throw err;
         }
     };

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -1,8 +1,6 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import {
-    getNotesForList,
-    getNotesForListByFolder,
-    getCollaborativeNotesForList,
     upsertSearchIndex,
     updateSearchIndexMetadata,
     deleteSearchIndexEntry,
@@ -12,8 +10,12 @@ import {
     updateSyncStatus,
     saveDocumentUpdate,
     getTrashedNotes,
-    getArchivedNotes,
+    getSearchIndexEntry,
     setNoteArchivalStatusLocal,
+    NOTE_LIST_SQL,
+    NOTE_ROW_KEY,
+    toNoteListEntry,
+    type NoteListRow,
 } from '@/lib/db';
 import * as Y from 'yjs';
 import { getNewId } from '@/lib/utils';
@@ -21,24 +23,11 @@ import type { NoteListEntry, SearchIndexEntry, DocumentMetadata } from '@/types'
 import { MAIN_FOLDER_ID } from '@/lib/homebase';
 import { useSyncService } from '@/hooks/useSyncService';
 import { formatGuidId } from '@homebase-id/js-lib/helpers';
-
-export const notesQueryKey = ['notes'] as const;
-export const trashedNotesQueryKey = ['trashed-notes'] as const;
-export const archivedNotesQueryKey = ['archived-notes'] as const;
+import { useLiveQuery } from './useLiveQuery';
 
 interface CreateNoteResult {
     docId: string;
     folderId: string;
-}
-
-interface NoteMutationContext {
-    previousNotes: NoteListEntry[] | undefined;
-}
-
-interface TrashMutationContext {
-    previousNotes?: NoteListEntry[] | undefined;
-    previousTrash?: NoteListEntry[] | undefined;
-    previousArchived?: NoteListEntry[] | undefined;
 }
 
 interface UpdateMetadataParams {
@@ -47,23 +36,52 @@ interface UpdateMetadataParams {
 }
 
 /**
+ * Subscribe to a note-list query as a PGlite live query. PGlite is the reactive
+ * source — any local or sync write re-emits results, so the list updates
+ * progressively with no manual invalidation.
+ */
+export function useLiveNoteList(
+    sql: string,
+    params: ReadonlyArray<unknown>,
+    enabled: boolean = true,
+): { data: NoteListEntry[]; isLoading: boolean } {
+    const { data: rows, isLoading } = useLiveQuery<NoteListRow>(sql, params, NOTE_ROW_KEY, enabled);
+    const data = useMemo(() => rows.map(toNoteListEntry), [rows]);
+    return { data, isLoading };
+}
+
+/**
  * Combined hook for managing notes.
- * Returns the query result and mutation hooks in a single object.
+ * Returns the live note list and mutation hooks in a single object.
+ *
+ * Reads are PGlite live queries (the DB is the reactive source). Mutations are
+ * local-first: they write to PGlite (which updates the UI via the live query)
+ * and then reconcile remotely. Soft-delete transitions (trash/archive) roll the
+ * local status back if the remote push fails, since a half-applied status would
+ * resurface on the next pull.
  */
 export function useNotes() {
-    const queryClient = useQueryClient();
     const { deleteNoteRemote, setNoteArchivalStatusRemote } = useSyncService();
 
-    // --- Queries ---
+    // --- Queries (live) ---
 
-    const query = useQuery<NoteListEntry[]>({
-        queryKey: notesQueryKey,
-        queryFn: getNotesForList,
-    });
+    const query = useLiveNoteList(NOTE_LIST_SQL.active, []);
+
+    // Local-first archival-status change with remote reconciliation + rollback.
+    const applyArchivalStatus = async (docId: string, status: number) => {
+        const prev = (await getSearchIndexEntry(docId))?.metadata.archivalStatus ?? 0;
+        await setNoteArchivalStatusLocal(docId, status);
+        try {
+            await setNoteArchivalStatusRemote(docId, status);
+        } catch (err) {
+            await setNoteArchivalStatusLocal(docId, prev);
+            throw err;
+        }
+    };
 
     // --- Mutations ---
 
-    const createNoteMutation = useMutation<CreateNoteResult, Error, string | undefined, NoteMutationContext>({
+    const createNoteMutation = useMutation<CreateNoteResult, Error, string | undefined>({
         mutationFn: async (targetFolderId?: string) => {
             const docId = formatGuidId(getNewId());
             const now = new Date().toISOString();
@@ -96,56 +114,25 @@ export function useNotes() {
 
             return { docId, folderId: metadata.folderId };
         },
-
-        onError: (_err, _vars, context) => {
-            if (context?.previousNotes) {
-                queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
-        },
     });
 
     // Permanent delete (used from the Trash view and for emptying trash).
-    const deleteNoteMutation = useMutation<void, Error, string, NoteMutationContext>({
+    // Remote-first: deleting locally before a confirmed remote delete would let
+    // the orphaned remote file resurface on the next pull.
+    const deleteNoteMutation = useMutation<void, Error, string>({
         mutationFn: async (docId: string) => {
-            // First delete from remote
             await deleteNoteRemote(docId);
 
-            // Then delete locally
             await Promise.all([
                 deleteSearchIndexEntry(docId),
                 deleteDocumentUpdates(docId),
                 deleteSyncRecord(docId),
             ]);
         },
-        onMutate: async (docId) => {
-            await queryClient.cancelQueries({ queryKey: notesQueryKey });
-            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-
-            queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) =>
-                old?.filter((n) => n.docId !== docId) || []
-            );
-            queryClient.setQueryData<NoteListEntry[]>(trashedNotesQueryKey, (old) =>
-                old?.filter((n) => n.docId !== docId) || []
-            );
-
-            return { previousNotes };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousNotes) {
-                queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
-            queryClient.invalidateQueries({ queryKey: trashedNotesQueryKey });
-        },
     });
 
     // Permanently delete every trashed note.
-    const emptyTrashMutation = useMutation<void, Error, void, { previousTrash: NoteListEntry[] | undefined }>({
+    const emptyTrashMutation = useMutation<void, Error, void>({
         mutationFn: async () => {
             const trashed = await getTrashedNotes();
             // Delete all in parallel; one failure must not abort the rest.
@@ -160,86 +147,23 @@ export function useNotes() {
                 })
             );
         },
-        onMutate: async () => {
-            await queryClient.cancelQueries({ queryKey: trashedNotesQueryKey });
-            const previousTrash = queryClient.getQueryData<NoteListEntry[]>(trashedNotesQueryKey);
-            queryClient.setQueryData<NoteListEntry[]>(trashedNotesQueryKey, []);
-            return { previousTrash };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousTrash) {
-                queryClient.setQueryData(trashedNotesQueryKey, context.previousTrash);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: trashedNotesQueryKey });
-        },
     });
 
-    const updateMetadataMutation = useMutation<void, Error, UpdateMetadataParams, NoteMutationContext>({
+    const updateMetadataMutation = useMutation<void, Error, UpdateMetadataParams>({
         mutationFn: async ({ docId, metadata }) => {
             await updateSearchIndexMetadata(docId, metadata.title, metadata);
-
             await updateSyncStatus(docId, 'pending');
-        },
-        onMutate: async ({ docId, metadata }) => {
-            await queryClient.cancelQueries({ queryKey: notesQueryKey });
-            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-
-            queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) =>
-                old?.map((n) =>
-                    n.docId === docId
-                        ? { ...n, title: metadata.title, metadata }
-                        : n
-                ) || []
-            );
-
-            return { previousNotes };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousNotes) {
-                queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
         },
     });
 
-    const togglePinMutation = useMutation<void, Error, { docId: string; isPinned: boolean }, NoteMutationContext>({
+    const togglePinMutation = useMutation<void, Error, { docId: string; isPinned: boolean }>({
         mutationFn: async ({ docId, isPinned }) => {
-            const notes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-            const currentNote = notes?.find((n) => n.docId === docId);
+            const current = await getSearchIndexEntry(docId);
+            if (!current) return;
 
-            if (!currentNote) return;
-
-            const updatedMetadata = { ...currentNote.metadata, isPinned };
-
-            await updateSearchIndexMetadata(docId, currentNote.title, updatedMetadata);
-
+            const updatedMetadata = { ...current.metadata, isPinned };
+            await updateSearchIndexMetadata(docId, current.title, updatedMetadata);
             await updateSyncStatus(docId, 'pending');
-        },
-        onMutate: async ({ docId, isPinned }) => {
-            await queryClient.cancelQueries({ queryKey: notesQueryKey });
-            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-
-            queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) =>
-                old?.map((n) =>
-                    n.docId === docId
-                        ? { ...n, metadata: { ...n.metadata, isPinned } }
-                        : n
-                ) || []
-            );
-
-            return { previousNotes };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousNotes) {
-                queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
         },
     });
 
@@ -247,40 +171,17 @@ export function useNotes() {
     // persisted remotely by makeNotePublic/makeNotePrivate, so this is a LOCAL-only
     // update — we intentionally do NOT mark the note 'pending' (a normal sync push
     // could disturb the Anonymous ACL).
-    const setNotePublicMutation = useMutation<void, Error, { docId: string; isPublic: boolean }, NoteMutationContext>({
+    const setNotePublicMutation = useMutation<void, Error, { docId: string; isPublic: boolean }>({
         mutationFn: async ({ docId, isPublic }) => {
-            const notes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-            const currentNote = notes?.find((n) => n.docId === docId);
-            if (!currentNote) return;
+            const current = await getSearchIndexEntry(docId);
+            if (!current) return;
 
-            const updatedMetadata = { ...currentNote.metadata, isPublic };
-            await updateSearchIndexMetadata(docId, currentNote.title, updatedMetadata);
-        },
-        onMutate: async ({ docId, isPublic }) => {
-            await queryClient.cancelQueries({ queryKey: notesQueryKey });
-            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-
-            queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) =>
-                old?.map((n) =>
-                    n.docId === docId
-                        ? { ...n, metadata: { ...n.metadata, isPublic } }
-                        : n
-                ) || []
-            );
-
-            return { previousNotes };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousNotes) {
-                queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            }
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
+            const updatedMetadata = { ...current.metadata, isPublic };
+            await updateSearchIndexMetadata(docId, current.title, updatedMetadata);
         },
     });
 
-    const createNoteWithContentMutation = useMutation<CreateNoteResult, Error, { title: string; content: string; folderId: string }, NoteMutationContext>({
+    const createNoteWithContentMutation = useMutation<CreateNoteResult, Error, { title: string; content: string; folderId: string }>({
         mutationFn: async ({ title, content, folderId }) => {
             const docId = formatGuidId(getNewId());
             const now = new Date().toISOString();
@@ -299,7 +200,7 @@ export function useNotes() {
             const fragment = ydoc.getXmlFragment('prosemirror');
 
             // Create Tiptap JSON structure equivalent for a paragraph
-            // But YJS manipulation is lower level. 
+            // But YJS manipulation is lower level.
             // We need to create XML elements.
             const paragraph = new Y.XmlElement('paragraph');
             if (content) {
@@ -332,147 +233,26 @@ export function useNotes() {
 
             return { docId, folderId: metadata.folderId };
         },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
-        },
     });
 
     // Soft delete — move a note to Trash (Homebase archivalStatus 2).
-    const trashNoteMutation = useMutation<void, Error, string, TrashMutationContext>({
-        mutationFn: async (docId: string) => {
-            await setNoteArchivalStatusRemote(docId, 2);
-            await setNoteArchivalStatusLocal(docId, 2);
-        },
-        onMutate: async (docId) => {
-            await queryClient.cancelQueries({ queryKey: notesQueryKey });
-            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-            const previousTrash = queryClient.getQueryData<NoteListEntry[]>(trashedNotesQueryKey);
-            const previousArchived = queryClient.getQueryData<NoteListEntry[]>(archivedNotesQueryKey);
-            // The note may be heading to Trash from the active list OR the Archive view.
-            const moved =
-                previousNotes?.find((n) => n.docId === docId) ??
-                previousArchived?.find((n) => n.docId === docId);
-            queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) =>
-                old?.filter((n) => n.docId !== docId) || []
-            );
-            queryClient.setQueryData<NoteListEntry[]>(archivedNotesQueryKey, (old) =>
-                old?.filter((n) => n.docId !== docId) || []
-            );
-            if (moved) {
-                queryClient.setQueryData<NoteListEntry[]>(trashedNotesQueryKey, (old) => [
-                    moved,
-                    ...(old || []).filter((n) => n.docId !== docId),
-                ]);
-            }
-            return { previousNotes, previousTrash, previousArchived };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousNotes) queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            if (context?.previousTrash) queryClient.setQueryData(trashedNotesQueryKey, context.previousTrash);
-            if (context?.previousArchived) queryClient.setQueryData(archivedNotesQueryKey, context.previousArchived);
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
-            queryClient.invalidateQueries({ queryKey: trashedNotesQueryKey });
-            queryClient.invalidateQueries({ queryKey: archivedNotesQueryKey });
-        },
+    const trashNoteMutation = useMutation<void, Error, string>({
+        mutationFn: (docId: string) => applyArchivalStatus(docId, 2),
     });
 
     // Restore a note from Trash (archivalStatus 0).
-    const restoreNoteMutation = useMutation<void, Error, string, TrashMutationContext>({
-        mutationFn: async (docId: string) => {
-            await setNoteArchivalStatusRemote(docId, 0);
-            await setNoteArchivalStatusLocal(docId, 0);
-        },
-        onMutate: async (docId) => {
-            await queryClient.cancelQueries({ queryKey: trashedNotesQueryKey });
-            const previousTrash = queryClient.getQueryData<NoteListEntry[]>(trashedNotesQueryKey);
-            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-            // Optimistically move the note from the trash list back into the active list.
-            const moved = previousTrash?.find((n) => n.docId === docId);
-            queryClient.setQueryData<NoteListEntry[]>(trashedNotesQueryKey, (old) =>
-                old?.filter((n) => n.docId !== docId) || []
-            );
-            if (moved) {
-                queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) => [
-                    moved,
-                    ...(old || []).filter((n) => n.docId !== docId),
-                ]);
-            }
-            return { previousNotes, previousTrash };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousNotes) queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            if (context?.previousTrash) queryClient.setQueryData(trashedNotesQueryKey, context.previousTrash);
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
-            queryClient.invalidateQueries({ queryKey: trashedNotesQueryKey });
-        },
+    const restoreNoteMutation = useMutation<void, Error, string>({
+        mutationFn: (docId: string) => applyArchivalStatus(docId, 0),
     });
 
     // Archive — move a note to the Archive (Homebase archivalStatus 1).
-    const archiveNoteMutation = useMutation<void, Error, string, TrashMutationContext>({
-        mutationFn: async (docId: string) => {
-            await setNoteArchivalStatusRemote(docId, 1);
-            await setNoteArchivalStatusLocal(docId, 1);
-        },
-        onMutate: async (docId) => {
-            await queryClient.cancelQueries({ queryKey: notesQueryKey });
-            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-            const previousArchived = queryClient.getQueryData<NoteListEntry[]>(archivedNotesQueryKey);
-            const moved = previousNotes?.find((n) => n.docId === docId);
-            queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) =>
-                old?.filter((n) => n.docId !== docId) || []
-            );
-            if (moved) {
-                queryClient.setQueryData<NoteListEntry[]>(archivedNotesQueryKey, (old) => [
-                    moved,
-                    ...(old || []).filter((n) => n.docId !== docId),
-                ]);
-            }
-            return { previousNotes, previousArchived };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousNotes) queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            if (context?.previousArchived) queryClient.setQueryData(archivedNotesQueryKey, context.previousArchived);
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
-            queryClient.invalidateQueries({ queryKey: archivedNotesQueryKey });
-        },
+    const archiveNoteMutation = useMutation<void, Error, string>({
+        mutationFn: (docId: string) => applyArchivalStatus(docId, 1),
     });
 
     // Unarchive — move a note from the Archive back to active (archivalStatus 0).
-    const unarchiveNoteMutation = useMutation<void, Error, string, TrashMutationContext>({
-        mutationFn: async (docId: string) => {
-            await setNoteArchivalStatusRemote(docId, 0);
-            await setNoteArchivalStatusLocal(docId, 0);
-        },
-        onMutate: async (docId) => {
-            await queryClient.cancelQueries({ queryKey: archivedNotesQueryKey });
-            const previousArchived = queryClient.getQueryData<NoteListEntry[]>(archivedNotesQueryKey);
-            const previousNotes = queryClient.getQueryData<NoteListEntry[]>(notesQueryKey);
-            const moved = previousArchived?.find((n) => n.docId === docId);
-            queryClient.setQueryData<NoteListEntry[]>(archivedNotesQueryKey, (old) =>
-                old?.filter((n) => n.docId !== docId) || []
-            );
-            if (moved) {
-                queryClient.setQueryData<NoteListEntry[]>(notesQueryKey, (old) => [
-                    moved,
-                    ...(old || []).filter((n) => n.docId !== docId),
-                ]);
-            }
-            return { previousNotes, previousArchived };
-        },
-        onError: (_err, _vars, context) => {
-            if (context?.previousNotes) queryClient.setQueryData(notesQueryKey, context.previousNotes);
-            if (context?.previousArchived) queryClient.setQueryData(archivedNotesQueryKey, context.previousArchived);
-        },
-        onSettled: () => {
-            queryClient.invalidateQueries({ queryKey: notesQueryKey });
-            queryClient.invalidateQueries({ queryKey: archivedNotesQueryKey });
-        },
+    const unarchiveNoteMutation = useMutation<void, Error, string>({
+        mutationFn: (docId: string) => applyArchivalStatus(docId, 0),
     });
 
     return {
@@ -495,20 +275,14 @@ export function useNotes() {
  * Query hook for the Trash view — notes with archivalStatus 2 (Removed).
  */
 export function useTrashedNotes() {
-    return useQuery<NoteListEntry[]>({
-        queryKey: trashedNotesQueryKey,
-        queryFn: getTrashedNotes,
-    });
+    return useLiveNoteList(NOTE_LIST_SQL.trashed, []);
 }
 
 /**
  * Query hook for the Archive view — notes with archivalStatus 1 (Archived).
  */
 export function useArchivedNotes() {
-    return useQuery<NoteListEntry[]>({
-        queryKey: archivedNotesQueryKey,
-        queryFn: getArchivedNotes,
-    });
+    return useLiveNoteList(NOTE_LIST_SQL.archived, []);
 }
 
 /**
@@ -516,17 +290,11 @@ export function useArchivedNotes() {
  * Returns lightweight NoteListEntry objects (no full content).
  */
 export function useNotesByFolder(folderId: string | undefined) {
-    return useQuery<NoteListEntry[]>({
-        queryKey: [...notesQueryKey, 'folder', folderId],
-        queryFn: () => getNotesForListByFolder(folderId!),
-        // 'trash' and 'shared' are pseudo-folders with their own views — skip the query.
-        enabled: !!folderId && folderId !== 'trash' && folderId !== 'shared' && folderId !== 'archive',
-    });
+    // 'trash', 'shared' and 'archive' are pseudo-folders with their own views — skip the query.
+    const enabled = !!folderId && folderId !== 'trash' && folderId !== 'shared' && folderId !== 'archive';
+    return useLiveNoteList(NOTE_LIST_SQL.byFolder, [folderId ?? ''], enabled);
 }
 
 export function useCollaborativeNotes() {
-    return useQuery<NoteListEntry[]>({
-        queryKey: [...notesQueryKey, 'collaborative'],
-        queryFn: getCollaborativeNotesForList,
-    });
+    return useLiveNoteList(NOTE_LIST_SQL.collaborative, []);
 }

--- a/src/hooks/usePeerNoteWebsocket.ts
+++ b/src/hooks/usePeerNoteWebsocket.ts
@@ -1,9 +1,7 @@
 import { useCallback, useRef, useEffect } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import type { DotYouClient, TypedConnectionNotification, NotificationType, TargetDrive, DeletedHomebaseFile, HomebaseFile } from '@homebase-id/js-lib/core';
 import { drivesEqual } from '@homebase-id/js-lib/helpers';
 import { useWebsocketSubscriber } from './useWebsocketSubscriber';
-import { notesQueryKey } from './useNotes';
 import { JOURNAL_DRIVE, JOURNAL_FILE_TYPE } from '@/lib/homebase';
 import type { SyncService } from '@/lib/homebase/SyncService';
 import { toast } from 'sonner';
@@ -24,7 +22,6 @@ export const usePeerNoteWebsocket = ({
     isEnabled,
     syncService,
 }: UsePeerNoteWebsocketOptions) => {
-    const queryClient = useQueryClient();
     const disconnectTimeRef = useRef<number | null>(null);
 
     // Refs for stable callbacks — avoids WebSocket resubscription on prop changes
@@ -56,15 +53,14 @@ export const usePeerNoteWebsocket = ({
             if (notification.header?.fileMetadata?.appData?.fileType !== JOURNAL_FILE_TYPE) return;
 
             if (notification.notificationType === 'fileAdded' || notification.notificationType === 'fileModified') {
+                // handleRemoteNote writes to PGlite; the note list live query picks it up.
                 await syncServiceRef.current.handleRemoteNote(notification.header);
-                queryClient.invalidateQueries({ queryKey: notesQueryKey });
             } else {
                 await syncServiceRef.current.handleDeletedNote(notification.header as unknown as DeletedHomebaseFile);
-                queryClient.invalidateQueries({ queryKey: notesQueryKey });
                 toast('This shared note has been deleted by the author');
             }
         },
-        [queryClient],
+        [],
     );
 
     const handleDisconnect = useCallback(() => {
@@ -80,12 +76,11 @@ export const usePeerNoteWebsocket = ({
             );
             if (freshFile) {
                 await syncServiceRef.current.handleRemoteNote(freshFile as unknown as HomebaseFile<string>);
-                queryClient.invalidateQueries({ queryKey: notesQueryKey });
             }
         } catch (error) {
             console.error('[PeerNoteWebsocket] Reconnect sync failed:', error);
         }
-    }, [queryClient]);
+    }, []);
 
     const shouldSubscribe = isEnabled && !!authorOdinId && !!noteUniqueId;
 

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getAllTags, getNotesForListByTag, updateSearchIndexMetadata, updateSyncStatus } from '@/lib/db';
-import { notesQueryKey } from './useNotes';
-import type { NoteListEntry, DocumentMetadata } from '@/types';
+import { getAllTags, updateSearchIndexMetadata, updateSyncStatus, NOTE_LIST_SQL } from '@/lib/db';
+import { useLiveNoteList } from './useNotes';
+import type { DocumentMetadata } from '@/types';
 
 export const tagsQueryKey = ['tags'] as const;
 
@@ -29,7 +29,8 @@ export function useTags() {
             updateSyncStatus(docId, 'pending'),
         ]);
 
-        queryClient.invalidateQueries({ queryKey: notesQueryKey });
+        // The note list is a live query (auto-updates); only the derived tag list
+        // still needs a manual refresh.
         queryClient.invalidateQueries({ queryKey: tagsQueryKey });
     };
 
@@ -45,7 +46,6 @@ export function useTags() {
             updateSyncStatus(docId, 'pending'),
         ]);
 
-        queryClient.invalidateQueries({ queryKey: notesQueryKey });
         queryClient.invalidateQueries({ queryKey: tagsQueryKey });
     };
 
@@ -53,9 +53,5 @@ export function useTags() {
 }
 
 export function useNotesByTag(tag: string | null) {
-    return useQuery<NoteListEntry[]>({
-        queryKey: [...notesQueryKey, 'tag', tag],
-        queryFn: () => getNotesForListByTag(tag!),
-        enabled: !!tag,
-    });
+    return useLiveNoteList(NOTE_LIST_SQL.byTag, [tag ?? ''], !!tag);
 }

--- a/src/layouts/JournalLayout.tsx
+++ b/src/layouts/JournalLayout.tsx
@@ -53,7 +53,6 @@ import {
   useCollaborativeNotes,
   useTrashedNotes,
   useArchivedNotes,
-  notesQueryKey,
 } from "@/hooks/useNotes";
 import { HiddenNotesView } from "@/components/layout/HiddenNotesView";
 import { useTags, useNotesByTag } from "@/hooks/useTags";
@@ -63,7 +62,6 @@ import { useFolders } from "@/hooks/useFolders";
 import { useThemePreference } from "@/hooks/useThemePreference";
 import { useDotYouClientContext } from "@/components/auth";
 import { NotesDriveProvider } from "@/lib/homebase/NotesDriveProvider";
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import EditorPage from "@/pages/EditorPage";
 import { journalDriveRequest } from "@/hooks/auth/useYouAuthAuthorization";
@@ -121,7 +119,6 @@ export default function JournalLayout() {
   // Homebase sync - auto-syncs on mount and focus
   useSyncService();
 
-  const queryClient = useQueryClient();
   const dotYouClient = useDotYouClientContext();
 
   // Focus / Zen mode state
@@ -694,9 +691,6 @@ export default function JournalLayout() {
             }}
             noteId={collaborativeNote.docId}
             noteTitle={collaborativeNote.title || "Untitled"}
-            onSuccess={() => {
-              queryClient.invalidateQueries({ queryKey: notesQueryKey });
-            }}
           />
         </Suspense>
       )}

--- a/src/lib/db/pglite-worker.ts
+++ b/src/lib/db/pglite-worker.ts
@@ -1,13 +1,14 @@
 import { PGlite } from '@electric-sql/pglite';
 import { worker } from '@electric-sql/pglite/worker';
 import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
+import { live } from '@electric-sql/pglite/live';
 
 worker({
   async init(options) {
     return new PGlite({
       dataDir: options.dataDir,
       loadDataDir: options.loadDataDir as Blob | undefined,
-      extensions: { pg_trgm },
+      extensions: { pg_trgm, live },
     });
   },
 });

--- a/src/lib/db/pglite.ts
+++ b/src/lib/db/pglite.ts
@@ -1,5 +1,7 @@
 import { PGliteWorker } from '@electric-sql/pglite/worker';
 import type { PGliteInterface } from '@electric-sql/pglite';
+import { live } from '@electric-sql/pglite/live';
+import type { PGliteWithLive } from '@electric-sql/pglite/live';
 import { MAIN_FOLDER_ID } from '../homebase';
 import {
   migrateFromV3,
@@ -23,10 +25,19 @@ export function getDatabase(): Promise<PGliteInterface> {
   return dbPromise;
 }
 
+/**
+ * Same singleton instance as getDatabase(), typed with the `live` extension
+ * so callers can use PGlite live queries (db.live.incrementalQuery).
+ */
+export function getLiveDatabase(): Promise<PGliteWithLive> {
+  return getDatabase() as Promise<PGliteWithLive>;
+}
+
 function createWorkerInstance(loadDataDir?: Blob): Promise<PGliteInterface> {
   const options: Record<string, unknown> = {
     dataDir: DATA_DIR,
     id: 'journal-pglite',
+    extensions: { live },
   };
   if (loadDataDir) {
     options.loadDataDir = loadDataDir;

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -7,13 +7,39 @@ import type { SearchIndexEntry, NoteListEntry, Folder, DocumentMetadata, SyncRec
 // Active = not archived (1) and not trashed (2).
 const ACTIVE_NOTES_FILTER = `COALESCE((metadata->>'archivalStatus')::int, 0) = 0`;
 
-type NoteListRow = { doc_id: string; title: string; preview: string; metadata: DocumentMetadata };
-const toNoteListEntry = (row: NoteListRow): NoteListEntry => ({
+export type NoteListRow = { doc_id: string; title: string; preview: string; metadata: DocumentMetadata };
+export const toNoteListEntry = (row: NoteListRow): NoteListEntry => ({
     docId: row.doc_id,
     title: row.title,
     preview: row.preview || '',
     metadata: row.metadata,
 });
+
+export const toFolder = (row: { id: string; name: string; created_at: Date }): Folder => ({
+    id: row.id,
+    name: row.name,
+    createdAt: row.created_at,
+});
+
+// Shared SQL for note-list reads — used by both the imperative getters and the
+// live-query hooks so they never drift. Row key for note queries is 'doc_id'.
+const NOTE_LIST_SELECT = `SELECT doc_id, title, LEFT(plain_text_content, 150) as preview, metadata FROM search_index`;
+const MODIFIED_DESC = `ORDER BY (metadata->'timestamps'->>'modified')::timestamp DESC NULLS LAST`;
+const PINNED_THEN_MODIFIED = `ORDER BY (metadata->>'isPinned')::boolean DESC NULLS LAST, (metadata->'timestamps'->>'modified')::timestamp DESC NULLS LAST`;
+
+export const NOTE_ROW_KEY = 'doc_id';
+export const FOLDER_ROW_KEY = 'id';
+
+export const NOTE_LIST_SQL = {
+    active: `${NOTE_LIST_SELECT} WHERE ${ACTIVE_NOTES_FILTER} ${MODIFIED_DESC}`,
+    byFolder: `${NOTE_LIST_SELECT} WHERE metadata->>'folderId' = $1 AND ${ACTIVE_NOTES_FILTER} ${MODIFIED_DESC}`,
+    collaborative: `${NOTE_LIST_SELECT} WHERE (metadata->>'isCollaborative')::boolean = true AND ${ACTIVE_NOTES_FILTER} ${PINNED_THEN_MODIFIED}`,
+    trashed: `${NOTE_LIST_SELECT} WHERE COALESCE((metadata->>'archivalStatus')::int, 0) = 2 ${MODIFIED_DESC}`,
+    archived: `${NOTE_LIST_SELECT} WHERE COALESCE((metadata->>'archivalStatus')::int, 0) = 1 ${MODIFIED_DESC}`,
+    byTag: `${NOTE_LIST_SELECT} WHERE metadata->'tags' ? $1 AND ${ACTIVE_NOTES_FILTER} ORDER BY (metadata->>'isPinned')::boolean DESC NULLS LAST, updated_at DESC`,
+} as const;
+
+export const FOLDERS_SQL = `SELECT id, name, created_at FROM folders ORDER BY name ASC`;
 
 
 


### PR DESCRIPTION
## What

Replaces React Query reads for notes/folders with **PGlite live queries** so the note/folder lists update progressively as data is written — the "WhatsApp effect" during first sync — and reworks mutations to be **local-first**.

Implements `docs/superpowers/specs/2026-04-21-progressive-sync-design.md`.

## Changes

### Foundation
- `live` extension wired into the PGlite worker + main instance; `getLiveDatabase()`.
- `useLiveQuery` generic hook: ref-counted shared subscriptions, `startTransition` for non-urgent emissions, render-phase reset on key change, retry-on-failure, `enabled` flag.

### Phase 1 — Reads → live queries
- `useNotes`: `get` / `useNotesByFolder` / `useCollaborativeNotes` / `useTrashedNotes` / `useArchivedNotes` via a `useLiveNoteList` helper over centralized `NOTE_LIST_SQL`.
- `useFolders.get` via `FOLDERS_SQL`; `useTags.useNotesByTag` via `NOTE_LIST_SQL.byTag`.
- The derived **tag list** stays in React Query (its set-returning SQL doesn't fit `incrementalQuery`); refreshed on tag add/remove and on sync pull.

### Phase 2 — Local-first mutations
- **trash / restore / archive / unarchive**: write local status (instant UI via the live query) → push remote → roll local back on remote failure. Rollback is **compare-and-swap** so a concurrent transition isn't clobbered.
- **togglePin / setNotePublic**: read current state from the DB instead of the RQ cache.
- **Permanent delete / emptyTrash / deleteFolder**: kept **remote-first** on purpose — deleting locally before a confirmed remote delete would let the orphan resurface on the next pull. Dead optimistic `onMutate`/`onError`/`onSettled` handlers removed.

### Cleanup
- Removed now-dead `invalidateQueries(notes/folders)` call sites across `SyncProvider`, `useJournalWebsocket`, `usePeerNoteWebsocket`, `EditorProvider`, `NoteList`, `Sidebar`, `JournalLayout`, and the query-key exports they relied on.

## Code review (multi-agent, adversarially verified)

A 4-dimension review (React/Vercel best-practices, live-query correctness, mutation correctness, invalidation-removal safety) found **5 real issues — none caught by build or tests** — all fixed in this PR:

| Sev | Issue | Fix |
|-----|-------|-----|
| **high** | Remount-while-pending leaked a live subscription + duplicate re-renders (deterministic under React 19 StrictMode) | Entries captured by identity; subscriptions that resolve for a discarded generation are torn down; stale emissions dropped |
| medium | Folder/tag switch flashed the previous query's notes (state never reset on key change) | Render-phase reset to the new key's snapshot — no stale frame |
| medium | Concurrent archival transitions could clobber each other on rollback | Compare-and-swap rollback |
| low | A failed subscription wedged the shared entry forever | Gate creation on a `subscribing` flag so a later mount retries |

## Verification
- `npm run lint` ✅ clean — **0 eslint-disable / ts-ignore in the diff** (fixed the `react-hooks/set-state-in-effect` + `exhaustive-deps` issues at the source via render-phase reset + `useLatest` refs).
- `npm run build` ✅ green.
- `npx vitest run` ✅ **259 passing** (adds `live_queries.test.ts` + `progressive_sync.test.ts` driving the real SQL through a live-enabled PGlite: cumulative emission + active/archived/trashed transitions).
- ✅ **Runtime smoke-tested** in `npm run dev` — confirmed working.

## Note on test coverage
Live queries run through the PGlite **worker**, which unit tests can't exercise (they use direct PGlite), and this project has no React Testing Library — so the hook's concurrency/lifecycle fixes are logic- and review-verified, then confirmed by the runtime smoke test rather than by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)