### PR TITLE
feat(editor): internal note links [[ + backlinks

### DIFF
--- a/src/__tests__/backlinks_live.test.ts
+++ b/src/__tests__/backlinks_live.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Backlinks live query: prove NOTE_LIST_SQL.backlinks (metadata->'linkedNoteIds' ? $1)
+ * surfaces linking notes reactively through PGlite's live extension, and honours the
+ * active filter — the contract the "Linked mentions" panel depends on.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import { live, type LiveNamespace } from '@electric-sql/pglite/live';
+import { NOTE_LIST_SQL, NOTE_ROW_KEY, type NoteListRow } from '@/lib/db/queries';
+
+type LiveDB = PGlite & { live: LiveNamespace };
+
+const TARGET = '60000000-0000-0000-0000-0000000000aa';
+const SRC1 = '60000000-0000-0000-0000-000000000001';
+const SRC2 = '60000000-0000-0000-0000-000000000002';
+const OTHER = '60000000-0000-0000-0000-000000000003';
+
+let db: LiveDB;
+
+async function insertNote(
+  id: string,
+  title: string,
+  opts: { linkedNoteIds?: string[]; archivalStatus?: number } = {}
+) {
+  const metadata = {
+    title,
+    folderId: 'main',
+    archivalStatus: opts.archivalStatus ?? 0,
+    timestamps: { created: '2026-01-01T00:00:00.000Z', modified: '2026-01-01T00:00:00.000Z' },
+    ...(opts.linkedNoteIds ? { linkedNoteIds: opts.linkedNoteIds } : {}),
+  };
+  await db.query(
+    `INSERT INTO search_index (doc_id, title, plain_text_content, metadata) VALUES ($1, $2, $3, $4)`,
+    [id, title, title, JSON.stringify(metadata)]
+  );
+}
+
+async function setLinks(id: string, linkedNoteIds: string[]) {
+  await db.query(
+    `UPDATE search_index
+     SET metadata = jsonb_set(metadata, '{linkedNoteIds}', $2::jsonb), updated_at = CURRENT_TIMESTAMP
+     WHERE doc_id = $1`,
+    [id, JSON.stringify(linkedNoteIds)]
+  );
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000) {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timed out waiting for live emission');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+beforeAll(async () => {
+  db = (await PGlite.create({ extensions: { live } })) as LiveDB;
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS search_index (
+      doc_id UUID PRIMARY KEY,
+      title TEXT NOT NULL DEFAULT 'Untitled',
+      plain_text_content TEXT DEFAULT '',
+      metadata JSONB NOT NULL DEFAULT '{}',
+      updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+});
+afterAll(async () => { await db.close(); });
+beforeEach(async () => { await db.exec(`DELETE FROM search_index;`); });
+
+describe('NOTE_LIST_SQL.backlinks — live linked-mentions', () => {
+  it('returns only notes whose linkedNoteIds contains the target', async () => {
+    await insertNote(SRC1, 'Links to target', { linkedNoteIds: [TARGET] });
+    await insertNote(OTHER, 'Links elsewhere', { linkedNoteIds: [SRC2] });
+    await insertNote(TARGET, 'The target', {});
+
+    const lq = await db.live.incrementalQuery<NoteListRow>(NOTE_LIST_SQL.backlinks, [TARGET], NOTE_ROW_KEY);
+    expect(lq.initialResults.rows.map((r) => r.title)).toEqual(['Links to target']);
+    await lq.unsubscribe();
+  });
+
+  it('reacts when a link is added then removed', async () => {
+    await insertNote(SRC1, 'Source', { linkedNoteIds: [] });
+    let rows: NoteListRow[] = [];
+    const lq = await db.live.incrementalQuery<NoteListRow>(
+      NOTE_LIST_SQL.backlinks, [TARGET], NOTE_ROW_KEY, (res) => { rows = res.rows; }
+    );
+    expect(lq.initialResults.rows).toHaveLength(0);
+
+    await setLinks(SRC1, [TARGET]);
+    await waitFor(() => rows.length === 1);
+    expect(rows[0].doc_id).toBe(SRC1);
+
+    await setLinks(SRC1, []);
+    await waitFor(() => rows.length === 0);
+
+    await lq.unsubscribe();
+  });
+
+  it('excludes archived/trashed sources even if they link to the target', async () => {
+    await insertNote(SRC1, 'Active source', { linkedNoteIds: [TARGET], archivalStatus: 0 });
+    await insertNote(SRC2, 'Archived source', { linkedNoteIds: [TARGET], archivalStatus: 1 });
+
+    const lq = await db.live.incrementalQuery<NoteListRow>(NOTE_LIST_SQL.backlinks, [TARGET], NOTE_ROW_KEY);
+    expect(lq.initialResults.rows.map((r) => r.doc_id)).toEqual([SRC1]);
+    await lq.unsubscribe();
+  });
+});

--- a/src/__tests__/extractNoteLinkIds.test.ts
+++ b/src/__tests__/extractNoteLinkIds.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { extractNoteLinkIds } from '@/lib/editor/extractNoteLinkIds';
+import type { JSONContent } from '@tiptap/core';
+
+const A = '40000000-0000-0000-0000-000000000001';
+const B = '40000000-0000-0000-0000-000000000002';
+
+const para = (...content: JSONContent[]): JSONContent => ({ type: 'paragraph', content });
+const text = (t: string): JSONContent => ({ type: 'text', text: t });
+const noteLink = (noteId: string, label = 'X'): JSONContent => ({
+  type: 'noteLink',
+  attrs: { noteId, label },
+});
+
+describe('extractNoteLinkIds', () => {
+  it('returns [] for an empty / link-free document', () => {
+    const doc: JSONContent = { type: 'doc', content: [para(text('hello world'))] };
+    expect(extractNoteLinkIds(doc)).toEqual([]);
+  });
+
+  it('collects noteIds from noteLink nodes anywhere in the tree', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        para(text('see '), noteLink(A), text(' and '), noteLink(B)),
+      ],
+    };
+    expect(extractNoteLinkIds(doc).sort()).toEqual([A, B].sort());
+  });
+
+  it('dedupes repeated links to the same note', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [para(noteLink(A)), para(noteLink(A))],
+    };
+    expect(extractNoteLinkIds(doc)).toEqual([A]);
+  });
+
+  it('finds links nested inside other block types (lists, quotes)', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'blockquote',
+          content: [
+            { type: 'bulletList', content: [
+              { type: 'listItem', content: [para(noteLink(B))] },
+            ] },
+          ],
+        },
+      ],
+    };
+    expect(extractNoteLinkIds(doc)).toEqual([B]);
+  });
+
+  it('ignores noteLink nodes without a noteId', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [para({ type: 'noteLink', attrs: { label: 'broken' } })],
+    };
+    expect(extractNoteLinkIds(doc)).toEqual([]);
+  });
+
+  it('handles null / empty input safely', () => {
+    expect(extractNoteLinkIds(null as unknown as JSONContent)).toEqual([]);
+    expect(extractNoteLinkIds({} as JSONContent)).toEqual([]);
+  });
+});

--- a/src/__tests__/note_links_queries.test.ts
+++ b/src/__tests__/note_links_queries.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/lib/db/pglite', () => {
     return { getDatabase: async () => testDb, setTestDb: (db: PGlite) => { testDb = db; } };
 });
 import * as pgliteModule from '@/lib/db/pglite';
-import { upsertSearchIndex, searchNotesByTitle } from '@/lib/db/queries';
+import { upsertSearchIndex, searchNotesByTitle, updateSearchIndexMetadata, getSearchIndexEntry } from '@/lib/db/queries';
 
 const SELF = '50000000-0000-0000-0000-0000000000ff';
 const N1 = '50000000-0000-0000-0000-000000000001';
@@ -38,6 +38,50 @@ beforeAll(async () => {
 });
 afterAll(async () => { await closeTestDatabase(); });
 beforeEach(async () => { await resetTestDatabase(); });
+
+describe('updateSearchIndexMetadata preserves editor-owned linkedNoteIds', () => {
+    it('keeps existing linkedNoteIds when a metadata-only write omits them', async () => {
+        const now = new Date().toISOString();
+        // A note that already has outgoing links (written by the content-save path).
+        await upsertSearchIndex({
+            docId: N1,
+            title: 'Has links',
+            plainTextContent: 'body',
+            metadata: {
+                title: 'Has links',
+                folderId: 'main',
+                timestamps: { created: now, modified: now },
+                excludeFromAI: false,
+                linkedNoteIds: [N2, N3],
+            },
+        });
+
+        // A title-only update whose metadata snapshot is stale (no linkedNoteIds).
+        await updateSearchIndexMetadata(N1, 'Renamed', {
+            title: 'Renamed',
+            folderId: 'main',
+            timestamps: { created: now, modified: now },
+            excludeFromAI: false,
+        });
+
+        const entry = await getSearchIndexEntry(N1);
+        expect(entry?.title).toBe('Renamed');
+        expect(entry?.metadata.linkedNoteIds).toEqual([N2, N3]);
+    });
+
+    it('does not invent linkedNoteIds for notes that never had them', async () => {
+        const now = new Date().toISOString();
+        await addNote(N1, 'No links');
+        await updateSearchIndexMetadata(N1, 'Still no links', {
+            title: 'Still no links',
+            folderId: 'main',
+            timestamps: { created: now, modified: now },
+            excludeFromAI: false,
+        });
+        const entry = await getSearchIndexEntry(N1);
+        expect(entry?.metadata.linkedNoteIds).toBeUndefined();
+    });
+});
 
 describe('searchNotesByTitle', () => {
     it('matches notes by case-insensitive title substring', async () => {

--- a/src/__tests__/note_links_queries.test.ts
+++ b/src/__tests__/note_links_queries.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import { createTestDatabase, closeTestDatabase, resetTestDatabase } from './testDb';
+
+vi.mock('@/lib/db/pglite', () => {
+    let testDb: PGlite | null = null;
+    return { getDatabase: async () => testDb, setTestDb: (db: PGlite) => { testDb = db; } };
+});
+import * as pgliteModule from '@/lib/db/pglite';
+import { upsertSearchIndex, searchNotesByTitle } from '@/lib/db/queries';
+
+const SELF = '50000000-0000-0000-0000-0000000000ff';
+const N1 = '50000000-0000-0000-0000-000000000001';
+const N2 = '50000000-0000-0000-0000-000000000002';
+const N3 = '50000000-0000-0000-0000-000000000003';
+
+async function addNote(docId: string, title: string, archivalStatus?: number, modified?: string) {
+    const now = modified ?? new Date().toISOString();
+    await upsertSearchIndex({
+        docId,
+        title,
+        plainTextContent: title,
+        metadata: {
+            title,
+            folderId: 'main',
+            timestamps: { created: now, modified: now },
+            excludeFromAI: false,
+            ...(archivalStatus !== undefined ? { archivalStatus } : {}),
+        },
+    });
+}
+
+let db: PGlite;
+beforeAll(async () => {
+    db = await createTestDatabase();
+    // @ts-expect-error test-only setter
+    pgliteModule.setTestDb(db);
+});
+afterAll(async () => { await closeTestDatabase(); });
+beforeEach(async () => { await resetTestDatabase(); });
+
+describe('searchNotesByTitle', () => {
+    it('matches notes by case-insensitive title substring', async () => {
+        await addNote(N1, 'Project Roadmap');
+        await addNote(N2, 'Grocery list');
+        const res = await searchNotesByTitle('road');
+        expect(res.map((n) => n.docId)).toEqual([N1]);
+    });
+
+    it('excludes the current note (self link)', async () => {
+        await addNote(SELF, 'Daily Journal');
+        await addNote(N1, 'Journal ideas');
+        const res = await searchNotesByTitle('journal', SELF);
+        expect(res.map((n) => n.docId)).toEqual([N1]);
+    });
+
+    it('excludes archived (1) and trashed (2) notes', async () => {
+        await addNote(N1, 'Note alpha', 0);
+        await addNote(N2, 'Note bravo', 1);
+        await addNote(N3, 'Note charlie', 2);
+        const res = await searchNotesByTitle('note');
+        expect(res.map((n) => n.docId)).toEqual([N1]);
+    });
+
+    it('returns recent active notes for an empty query, respecting the limit', async () => {
+        await addNote(N1, 'One', 0, '2026-01-01T00:00:01.000Z');
+        await addNote(N2, 'Two', 0, '2026-01-01T00:00:02.000Z');
+        await addNote(N3, 'Three', 0, '2026-01-01T00:00:03.000Z');
+        const res = await searchNotesByTitle('', undefined, 2);
+        expect(res).toHaveLength(2);
+        // most-recently-modified first
+        expect(res[0].docId).toBe(N3);
+    });
+});

--- a/src/__tests__/testDb.ts
+++ b/src/__tests__/testDb.ts
@@ -34,6 +34,7 @@ export async function createTestDatabase(): Promise<PGlite> {
       title TEXT NOT NULL DEFAULT 'Untitled',
       plain_text_content TEXT DEFAULT '',
       metadata JSONB NOT NULL DEFAULT '{}',
+      search_vector tsvector,
       vector_embedding REAL[],
       updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
     );

--- a/src/components/editor/EditorProvider.tsx
+++ b/src/components/editor/EditorProvider.tsx
@@ -16,8 +16,8 @@ import type { DocumentMetadata } from "@/types";
 import { EditorContext } from "./EditorContext";
 import { NoteLinkContext, type NoteLinkContextValue } from "./NoteLinkContext";
 import { useSyncService } from "@/hooks/useSyncService";
-import { useNotes } from "@/hooks/useNotes";
 import { useNoteTitleMap } from "@/hooks/useNoteTitleMap";
+import { createNoteWithContent } from "@/lib/notes/createNoteWithContent";
 import { extractNoteLinkIds } from "@/lib/editor/extractNoteLinkIds";
 import { useImageDeletionTracker } from "./hooks/useImageDeletionTracker";
 import { useDocumentSubscription } from "@/hooks/useDocumentSubscription"; // Import the hook
@@ -186,24 +186,22 @@ export function EditorProvider({
 
   // --- Internal note links (`[[`) ---
   const navigate = useNavigate();
-  const noteTitleMap = useNoteTitleMap();
-  const { createNoteWithContent } = useNotes();
-  const createNoteAsync = createNoteWithContent.mutateAsync;
+  const { map: noteTitleMap, isReady: titleMapReady } = useNoteTitleMap();
   const noteFolderId = metadata.folderId;
 
   // Handlers for the suggestion extension. EditorProvider remounts per note
   // (key={noteId}), so docId/folderId are stable for this instance — close over
-  // them directly rather than reading refs during render.
+  // them directly. createNoteWithContent is a plain fn (no list subscription).
   const onCreateNoteLink = useCallback(
     async (title: string) => {
-      const res = await createNoteAsync({
+      const res = await createNoteWithContent({
         title,
         content: "",
         folderId: noteFolderId,
       });
       return res ? { docId: res.docId } : null;
     },
-    [createNoteAsync, noteFolderId],
+    [noteFolderId],
   );
   const getCurrentNoteId = useCallback(() => docId, [docId]);
 
@@ -211,12 +209,13 @@ export function EditorProvider({
   const noteLinkValue = useMemo<NoteLinkContextValue>(
     () => ({
       resolve: (id) => noteTitleMap.get(id),
+      isReady: titleMapReady,
       onNavigate: (id) => {
         const r = noteTitleMap.get(id);
         if (r) navigate(`/${r.folderId}/${id}`, { viewTransition: true });
       },
     }),
-    [noteTitleMap, navigate],
+    [noteTitleMap, titleMapReady, navigate],
   );
 
   // Memoize extensions to avoid recreation on every render

--- a/src/components/editor/EditorProvider.tsx
+++ b/src/components/editor/EditorProvider.tsx
@@ -7,15 +7,22 @@ import {
   type ReactNode,
 } from "react";
 import { useAISettings } from "@/hooks/useAISettings";
+import { useNavigate } from "react-router-dom";
 import { useEditor, type Editor } from "@tiptap/react";
 import * as Y from "yjs";
 import { PGliteProvider } from "@/lib/yjs";
 import { upsertSearchIndex, savePendingImageUpload } from "@/lib/db";
 import type { DocumentMetadata } from "@/types";
 import { EditorContext } from "./EditorContext";
+import { NoteLinkContext, type NoteLinkContextValue } from "./NoteLinkContext";
 import { useSyncService } from "@/hooks/useSyncService";
+import { useNotes } from "@/hooks/useNotes";
+import { useNoteTitleMap } from "@/hooks/useNoteTitleMap";
+import { extractNoteLinkIds } from "@/lib/editor/extractNoteLinkIds";
 import { useImageDeletionTracker } from "./hooks/useImageDeletionTracker";
 import { useDocumentSubscription } from "@/hooks/useDocumentSubscription"; // Import the hook
+import { NoteLink } from "./nodes/NoteLinkNode";
+import { NoteLinkExtension } from "./plugins/NoteLink";
 import {
   createBaseExtensions,
   createCollaborationExtension,
@@ -165,6 +172,53 @@ export function EditorProvider({
 
   useDocumentSubscription(docId, handleDocumentUpdate);
 
+  // Refs for current values - avoids stale closures in debounced functions
+  const docIdRef = useRef(docId);
+  const metadataRef = useRef(metadata);
+  const onSaveRef = useRef(onSave);
+
+  // Keep refs in sync with props
+  useEffect(() => {
+    docIdRef.current = docId;
+    metadataRef.current = metadata;
+    onSaveRef.current = onSave;
+  }, [docId, metadata, onSave]);
+
+  // --- Internal note links (`[[`) ---
+  const navigate = useNavigate();
+  const noteTitleMap = useNoteTitleMap();
+  const { createNoteWithContent } = useNotes();
+  const createNoteAsync = createNoteWithContent.mutateAsync;
+  const noteFolderId = metadata.folderId;
+
+  // Handlers for the suggestion extension. EditorProvider remounts per note
+  // (key={noteId}), so docId/folderId are stable for this instance — close over
+  // them directly rather than reading refs during render.
+  const onCreateNoteLink = useCallback(
+    async (title: string) => {
+      const res = await createNoteAsync({
+        title,
+        content: "",
+        folderId: noteFolderId,
+      });
+      return res ? { docId: res.docId } : null;
+    },
+    [createNoteAsync, noteFolderId],
+  );
+  const getCurrentNoteId = useCallback(() => docId, [docId]);
+
+  // Live title/navigation resolver for note-link chips + backlinks.
+  const noteLinkValue = useMemo<NoteLinkContextValue>(
+    () => ({
+      resolve: (id) => noteTitleMap.get(id),
+      onNavigate: (id) => {
+        const r = noteTitleMap.get(id);
+        if (r) navigate(`/${r.folderId}/${id}`, { viewTransition: true });
+      },
+    }),
+    [noteTitleMap, navigate],
+  );
+
   // Memoize extensions to avoid recreation on every render
   const extensions = useMemo(
     () => [
@@ -190,6 +244,12 @@ export function EditorProvider({
       }),
       // Slash commands (triggered by typing /)
       SlashCommandsExtension,
+      // Internal note links — `[[` suggestion + the noteLink node it inserts
+      NoteLink,
+      NoteLinkExtension.configure({
+        onCreateNote: onCreateNoteLink,
+        getCurrentNoteId,
+      }),
       // Grammar plugin — always included, checks getIsGrammarEnabled() at runtime
       // eslint-disable-next-line react-hooks/refs -- getIsAIReady/getIsGrammarEnabled are getters called only within plugin execution, not during render
       GrammarPlugin.configure({
@@ -206,6 +266,8 @@ export function EditorProvider({
       onGetAutocompleteSuggestion,
       onCheckGrammar,
       handleImageDrop,
+      onCreateNoteLink,
+      getCurrentNoteId,
     ],
   );
 
@@ -241,18 +303,6 @@ export function EditorProvider({
     [extensions],
   );
 
-  // Refs for current values - avoids stale closures in debounced functions
-  const docIdRef = useRef(docId);
-  const metadataRef = useRef(metadata);
-  const onSaveRef = useRef(onSave);
-
-  // Keep refs in sync with props
-  useEffect(() => {
-    docIdRef.current = docId;
-    metadataRef.current = metadata;
-    onSaveRef.current = onSave;
-  }, [docId, metadata, onSave]);
-
   // Timeout refs for cleanup
   const searchIndexTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -270,6 +320,8 @@ export function EditorProvider({
         const currentMetadata = metadataRef.current;
         // Use passed plainText if available, otherwise fallback
         const plainText = plainTextContent ?? editorInstance.getText();
+        // Recompute outgoing internal links — powers the backlinks live query.
+        const linkedNoteIds = extractNoteLinkIds(editorInstance.getJSON());
 
         upsertSearchIndex({
           docId: currentDocId,
@@ -282,6 +334,7 @@ export function EditorProvider({
               ...currentMetadata.timestamps,
               modified: new Date().toISOString(),
             },
+            linkedNoteIds,
             lastEditedBy: currentMetadata.isCollaborative
               ? editorOdinId
               : currentMetadata.lastEditedBy,
@@ -361,6 +414,10 @@ export function EditorProvider({
   };
 
   return (
-    <EditorContext.Provider value={value}>{children}</EditorContext.Provider>
+    <EditorContext.Provider value={value}>
+      <NoteLinkContext.Provider value={noteLinkValue}>
+        {children}
+      </NoteLinkContext.Provider>
+    </EditorContext.Provider>
   );
 }

--- a/src/components/editor/LinkedMentions.tsx
+++ b/src/components/editor/LinkedMentions.tsx
@@ -1,0 +1,67 @@
+/**
+ * "Linked mentions" (backlinks) panel shown at the bottom of a note — the active
+ * notes that link to this one via `[[`. Reactive: backed by a PGlite live query,
+ * so new/removed links appear without a refresh. Hidden when there are none.
+ */
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ChevronDown, ChevronRight, Link2 } from "lucide-react";
+import { useBacklinks } from "@/hooks/useNotes";
+import { cn } from "@/lib/utils";
+
+export function LinkedMentions({ noteId }: { noteId: string }) {
+  const { data: backlinks } = useBacklinks(noteId);
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(true);
+
+  if (backlinks.length === 0) return null;
+
+  return (
+    <section className="mt-8 border-t border-border pt-4">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {open ? (
+          <ChevronDown className="h-4 w-4" />
+        ) : (
+          <ChevronRight className="h-4 w-4" />
+        )}
+        <Link2 className="h-4 w-4" />
+        <span>Linked mentions ({backlinks.length})</span>
+      </button>
+
+      {open && (
+        <ul className="mt-2 space-y-1">
+          {backlinks.map((note) => (
+            <li key={note.docId}>
+              <button
+                type="button"
+                onClick={() =>
+                  navigate(`/${note.metadata.folderId}/${note.docId}`, {
+                    viewTransition: true,
+                  })
+                }
+                className={cn(
+                  "flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left",
+                  "hover:bg-muted/50 transition-colors",
+                )}
+              >
+                <span className="text-sm font-medium truncate w-full">
+                  {note.title || "Untitled"}
+                </span>
+                {note.preview && (
+                  <span className="text-xs text-muted-foreground line-clamp-1 w-full">
+                    {note.preview}
+                  </span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/editor/NoteLinkContext.tsx
+++ b/src/components/editor/NoteLinkContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react";
+
+export interface NoteLinkResolution {
+  title: string;
+  folderId: string;
+  status: number; // Homebase archivalStatus: 0 active, 1 archived, 2 trashed
+}
+
+export interface NoteLinkContextValue {
+  /** Resolve a target note's current title/folder/status, or undefined if it doesn't exist locally. */
+  resolve: (noteId: string) => NoteLinkResolution | undefined;
+  /** Navigate to a linked note. */
+  onNavigate: (noteId: string) => void;
+}
+
+/**
+ * Supplies note-link node views with live title resolution + navigation. Lives
+ * above the editor so every `noteLink` chip reflects the target's current title
+ * (renames propagate) and can navigate on click.
+ */
+export const NoteLinkContext = createContext<NoteLinkContextValue | null>(null);
+
+export function useNoteLinkContext(): NoteLinkContextValue | null {
+  return useContext(NoteLinkContext);
+}

--- a/src/components/editor/NoteLinkContext.tsx
+++ b/src/components/editor/NoteLinkContext.tsx
@@ -3,12 +3,13 @@ import { createContext, useContext } from "react";
 export interface NoteLinkResolution {
   title: string;
   folderId: string;
-  status: number; // Homebase archivalStatus: 0 active, 1 archived, 2 trashed
 }
 
 export interface NoteLinkContextValue {
-  /** Resolve a target note's current title/folder/status, or undefined if it doesn't exist locally. */
+  /** Resolve a target note's current title/folder, or undefined if not an active note. */
   resolve: (noteId: string) => NoteLinkResolution | undefined;
+  /** True once the title map's first emission has arrived (distinguishes loading from missing). */
+  isReady: boolean;
   /** Navigate to a linked note. */
   onNavigate: (noteId: string) => void;
 }

--- a/src/components/editor/nodes/NoteLinkNode.ts
+++ b/src/components/editor/nodes/NoteLinkNode.ts
@@ -1,0 +1,67 @@
+/**
+ * Internal note-link node (`[[`).
+ *
+ * Inline atom carrying the stable target `noteId` plus a `label` snapshot
+ * (used for plain-text/export and as the fallback when the target can't be
+ * resolved). The displayed title is resolved live (see NoteLinkNodeView), so
+ * renaming a note updates every link to it.
+ */
+import { Node, mergeAttributes } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { NoteLinkNodeView } from "./NoteLinkNodeView";
+
+export interface NoteLinkAttributes {
+  noteId: string | null;
+  label: string;
+}
+
+export const NoteLink = Node.create({
+  name: "noteLink",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: true,
+  draggable: false,
+
+  addAttributes() {
+    return {
+      noteId: {
+        default: null,
+        parseHTML: (el) => el.getAttribute("data-note-id"),
+        renderHTML: (attrs) =>
+          attrs.noteId ? { "data-note-id": attrs.noteId } : {},
+      },
+      label: {
+        default: "",
+        parseHTML: (el) =>
+          el.getAttribute("data-label") || el.textContent || "",
+        // label is carried via the element's text content, not a separate attr
+        renderHTML: () => ({}),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "a[data-note-id]" }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      "a",
+      mergeAttributes(HTMLAttributes, {
+        "data-note-id": node.attrs.noteId,
+        "data-label": node.attrs.label,
+        class: "note-link",
+      }),
+      node.attrs.label || "note",
+    ];
+  },
+
+  renderText({ node }) {
+    return node.attrs.label || "";
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(NoteLinkNodeView);
+  },
+});

--- a/src/components/editor/nodes/NoteLinkNodeView.tsx
+++ b/src/components/editor/nodes/NoteLinkNodeView.tsx
@@ -12,8 +12,9 @@ export function NoteLinkNodeView({ node }: NodeViewProps) {
   const label = (node.attrs.label as string) || "note";
 
   const resolved = noteId ? ctx?.resolve(noteId) : undefined;
-  // Broken = we have a resolver but the target isn't there (deleted/foreign id).
-  const broken = !!noteId && !!ctx && !resolved;
+  // Broken only once the title map has loaded and the target is genuinely absent
+  // (deleted / archived / foreign id). While loading, show the label, not ⚠.
+  const broken = !!noteId && !!ctx && ctx.isReady && !resolved;
   const display = resolved?.title ?? label;
 
   return (

--- a/src/components/editor/nodes/NoteLinkNodeView.tsx
+++ b/src/components/editor/nodes/NoteLinkNodeView.tsx
@@ -1,0 +1,35 @@
+/**
+ * React node view for the internal note-link node. The displayed title is
+ * resolved live from NoteLinkContext, so renaming a note updates every link to
+ * it; a missing target renders muted and non-clickable.
+ */
+import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
+import { useNoteLinkContext } from "../NoteLinkContext";
+
+export function NoteLinkNodeView({ node }: NodeViewProps) {
+  const ctx = useNoteLinkContext();
+  const noteId = (node.attrs.noteId as string | null) ?? "";
+  const label = (node.attrs.label as string) || "note";
+
+  const resolved = noteId ? ctx?.resolve(noteId) : undefined;
+  // Broken = we have a resolver but the target isn't there (deleted/foreign id).
+  const broken = !!noteId && !!ctx && !resolved;
+  const display = resolved?.title ?? label;
+
+  return (
+    <NodeViewWrapper as="span" className="note-link-wrapper">
+      <button
+        type="button"
+        contentEditable={false}
+        data-note-id={noteId}
+        className={broken ? "note-link note-link--broken" : "note-link"}
+        title={broken ? "Note not found" : display}
+        onClick={() => {
+          if (!broken && noteId) ctx?.onNavigate(noteId);
+        }}
+      >
+        {broken ? `⚠ ${label}` : display}
+      </button>
+    </NodeViewWrapper>
+  );
+}

--- a/src/components/editor/plugins/NoteLink/NoteLinkExtension.ts
+++ b/src/components/editor/plugins/NoteLink/NoteLinkExtension.ts
@@ -29,16 +29,13 @@ export interface NoteLinkOptions {
 
 type Range = { from: number; to: number };
 
+const noteLinkContent = (noteId: string, label: string) => [
+    { type: 'noteLink', attrs: { noteId, label } },
+    { type: 'text', text: ' ' },
+];
+
 function insertNoteLink(editor: Editor, range: Range, noteId: string, label: string) {
-    editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertContent([
-            { type: 'noteLink', attrs: { noteId, label } },
-            { type: 'text', text: ' ' },
-        ])
-        .run();
+    editor.chain().focus().deleteRange(range).insertContent(noteLinkContent(noteId, label)).run();
 }
 
 export const NoteLinkExtension = Extension.create<NoteLinkOptions>({
@@ -54,24 +51,52 @@ export const NoteLinkExtension = Extension.create<NoteLinkOptions>({
 
     addProseMirrorPlugins() {
         const options = this.options;
+        // Monotonic id so a slow earlier query can't overwrite a newer result.
+        let requestSeq = 0;
         return [
             Suggestion<NoteLinkItem>({
                 editor: this.editor,
                 char: '[[',
                 allowSpaces: true,
                 startOfLine: false,
+
+                // Match `[[` then any chars except `]`, `[` or newline, up to the
+                // cursor. Excluding `]` makes `]]` terminate the query (popup
+                // closes) — the natural [[Title]] syntax, which the default
+                // allowSpaces matcher would over-run to end of line.
+                findSuggestionMatch: ({ $position }) => {
+                    const textBefore = $position.parent.textBetween(
+                        0,
+                        $position.parentOffset,
+                        undefined,
+                        '￼',
+                    );
+                    const m = /\[\[([^[\]\n]*)$/.exec(textBefore);
+                    if (!m) return null;
+                    return {
+                        range: { from: $position.pos - m[0].length, to: $position.pos },
+                        query: m[1],
+                        text: m[0],
+                    };
+                },
+
                 ...options.suggestion,
 
-                items: async ({ query }) => {
-                    const notes = await searchNotesByTitle(query, options.getCurrentNoteId());
-                    const items: NoteLinkItem[] = notes.map((n) => ({
-                        type: 'note',
-                        docId: n.docId,
-                        title: n.title || 'Untitled',
-                    }));
-                    const q = query.trim();
-                    if (q) items.push({ type: 'create', title: q });
-                    return items;
+                items: ({ query }) => {
+                    const seq = ++requestSeq;
+                    return searchNotesByTitle(query, options.getCurrentNoteId()).then((notes) => {
+                        // Stale result (a newer query started) — drop it instead of
+                        // overwriting fresher items. Never-resolving = no onUpdate.
+                        if (seq !== requestSeq) return new Promise<NoteLinkItem[]>(() => {});
+                        const items: NoteLinkItem[] = notes.map((n) => ({
+                            type: 'note',
+                            docId: n.docId,
+                            title: n.title || 'Untitled',
+                        }));
+                        const q = query.trim();
+                        if (q) items.push({ type: 'create', title: q });
+                        return items;
+                    });
                 },
 
                 command: ({ editor, range, props }) => {
@@ -80,19 +105,23 @@ export const NoteLinkExtension = Extension.create<NoteLinkOptions>({
                         insertNoteLink(editor, range, item.docId, item.title);
                         return;
                     }
-                    // Create-on-the-fly: clear the `[[query` first, then link once created.
+                    // Create-on-the-fly: clear the `[[query`, create, then link at the
+                    // same spot. On failure, restore the typed text so it isn't lost.
+                    const from = range.from;
                     editor.chain().focus().deleteRange(range).run();
-                    void options.onCreateNote(item.title).then((res) => {
-                        if (!res?.docId) return;
-                        editor
-                            .chain()
-                            .focus()
-                            .insertContent([
-                                { type: 'noteLink', attrs: { noteId: res.docId, label: item.title } },
-                                { type: 'text', text: ' ' },
-                            ])
-                            .run();
-                    });
+                    void options
+                        .onCreateNote(item.title)
+                        .then((res) => {
+                            if (res?.docId) {
+                                editor.chain().focus().insertContentAt(from, noteLinkContent(res.docId, item.title)).run();
+                            } else {
+                                editor.chain().focus().insertContentAt(from, `[[${item.title}`).run();
+                            }
+                        })
+                        .catch((err) => {
+                            console.error('[NoteLink] create note failed:', err);
+                            editor.chain().focus().insertContentAt(from, `[[${item.title}`).run();
+                        });
                 },
 
                 render: () => {

--- a/src/components/editor/plugins/NoteLink/NoteLinkExtension.ts
+++ b/src/components/editor/plugins/NoteLink/NoteLinkExtension.ts
@@ -1,0 +1,151 @@
+/**
+ * Note-link suggestion extension (`[[`).
+ *
+ * Triggered by typing `[[`, it searches notes by title and inserts a `noteLink`
+ * node (see NoteLinkNode). When the query matches nothing it offers a
+ * "Create '<query>'" action that creates a note and links it inline.
+ * Reuses the same @tiptap/suggestion + ReactRenderer + tippy plumbing as the
+ * slash-command palette.
+ */
+import { Extension } from '@tiptap/core';
+import type { Editor } from '@tiptap/core';
+import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion';
+import { ReactRenderer } from '@tiptap/react';
+import tippy, { type Instance as TippyInstance } from 'tippy.js';
+import { NoteLinkList, type NoteLinkListRef } from './NoteLinkList';
+import { searchNotesByTitle } from '@/lib/db';
+
+export type NoteLinkItem =
+    | { type: 'note'; docId: string; title: string }
+    | { type: 'create'; title: string };
+
+export interface NoteLinkOptions {
+    /** Create a new note titled `title`; return its docId (or null to abort). */
+    onCreateNote: (title: string) => Promise<{ docId: string } | null>;
+    /** The note currently being edited — excluded from results (no self-links). */
+    getCurrentNoteId: () => string | undefined;
+    suggestion: Partial<SuggestionOptions>;
+}
+
+type Range = { from: number; to: number };
+
+function insertNoteLink(editor: Editor, range: Range, noteId: string, label: string) {
+    editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent([
+            { type: 'noteLink', attrs: { noteId, label } },
+            { type: 'text', text: ' ' },
+        ])
+        .run();
+}
+
+export const NoteLinkExtension = Extension.create<NoteLinkOptions>({
+    name: 'noteLinkSuggestion',
+
+    addOptions() {
+        return {
+            onCreateNote: async () => null,
+            getCurrentNoteId: () => undefined,
+            suggestion: {},
+        };
+    },
+
+    addProseMirrorPlugins() {
+        const options = this.options;
+        return [
+            Suggestion<NoteLinkItem>({
+                editor: this.editor,
+                char: '[[',
+                allowSpaces: true,
+                startOfLine: false,
+                ...options.suggestion,
+
+                items: async ({ query }) => {
+                    const notes = await searchNotesByTitle(query, options.getCurrentNoteId());
+                    const items: NoteLinkItem[] = notes.map((n) => ({
+                        type: 'note',
+                        docId: n.docId,
+                        title: n.title || 'Untitled',
+                    }));
+                    const q = query.trim();
+                    if (q) items.push({ type: 'create', title: q });
+                    return items;
+                },
+
+                command: ({ editor, range, props }) => {
+                    const item = props as NoteLinkItem;
+                    if (item.type === 'note') {
+                        insertNoteLink(editor, range, item.docId, item.title);
+                        return;
+                    }
+                    // Create-on-the-fly: clear the `[[query` first, then link once created.
+                    editor.chain().focus().deleteRange(range).run();
+                    void options.onCreateNote(item.title).then((res) => {
+                        if (!res?.docId) return;
+                        editor
+                            .chain()
+                            .focus()
+                            .insertContent([
+                                { type: 'noteLink', attrs: { noteId: res.docId, label: item.title } },
+                                { type: 'text', text: ' ' },
+                            ])
+                            .run();
+                    });
+                },
+
+                render: () => {
+                    let component: ReactRenderer<NoteLinkListRef> | null = null;
+                    let popup: TippyInstance[] | null = null;
+
+                    return {
+                        onStart: (props) => {
+                            component = new ReactRenderer(NoteLinkList, {
+                                props,
+                                editor: props.editor,
+                            });
+
+                            if (!props.clientRect) return;
+
+                            popup = tippy('body', {
+                                getReferenceClientRect: props.clientRect as () => DOMRect,
+                                appendTo: () => document.body,
+                                content: component.element,
+                                showOnCreate: true,
+                                interactive: true,
+                                trigger: 'manual',
+                                placement: 'bottom-start',
+                                animation: 'shift-away',
+                                offset: [0, 8],
+                            });
+                        },
+
+                        onUpdate: (props) => {
+                            component?.updateProps(props);
+                            if (!props.clientRect || !popup?.[0]) return;
+                            popup[0].setProps({
+                                getReferenceClientRect: props.clientRect as () => DOMRect,
+                            });
+                        },
+
+                        onKeyDown: (props) => {
+                            if (props.event.key === 'Escape') {
+                                popup?.[0]?.hide();
+                                return true;
+                            }
+                            return component?.ref?.onKeyDown(props) ?? false;
+                        },
+
+                        onExit: () => {
+                            popup?.[0]?.destroy();
+                            component?.destroy();
+                        },
+                    };
+                },
+            }),
+        ];
+    },
+});
+
+export default NoteLinkExtension;

--- a/src/components/editor/plugins/NoteLink/NoteLinkList.tsx
+++ b/src/components/editor/plugins/NoteLink/NoteLinkList.tsx
@@ -1,0 +1,100 @@
+/**
+ * Popup list for the `[[` note-link picker. Mirrors SlashCommandList: keyboard
+ * navigation + click selection, driven by @tiptap/suggestion render props.
+ */
+import { useState, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
+import { FileText, Plus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { NoteLinkItem } from './NoteLinkExtension';
+
+export interface NoteLinkListRef {
+    onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+}
+
+interface NoteLinkListProps {
+    items: NoteLinkItem[];
+    command: (item: NoteLinkItem) => void;
+    query: string;
+}
+
+export const NoteLinkList = forwardRef<NoteLinkListRef, NoteLinkListProps>(
+    ({ items, command, query }, ref) => {
+        const [selectedIndex, setSelectedIndex] = useState(0);
+
+        useEffect(() => {
+            setSelectedIndex(0);
+        }, [items]);
+
+        const selectItem = useCallback(
+            (index: number) => {
+                const item = items[index];
+                if (item) command(item);
+            },
+            [items, command],
+        );
+
+        useImperativeHandle(
+            ref,
+            () => ({
+                onKeyDown: ({ event }: { event: KeyboardEvent }) => {
+                    if (event.key === 'ArrowUp') {
+                        setSelectedIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1));
+                        return true;
+                    }
+                    if (event.key === 'ArrowDown') {
+                        setSelectedIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1));
+                        return true;
+                    }
+                    if (event.key === 'Enter') {
+                        selectItem(selectedIndex);
+                        return true;
+                    }
+                    return false;
+                },
+            }),
+            [items, selectItem, selectedIndex],
+        );
+
+        if (items.length === 0) {
+            return (
+                <div className="z-50 w-72 rounded-lg border border-border bg-popover p-2 shadow-lg">
+                    <p className="text-sm text-muted-foreground px-2 py-1">
+                        {query ? 'No notes found' : 'Type to search notes…'}
+                    </p>
+                </div>
+            );
+        }
+
+        return (
+            <div className="z-50 w-72 max-h-80 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-lg animate-in fade-in-0 zoom-in-95">
+                {items.map((item, index) => {
+                    const isSelected = index === selectedIndex;
+                    const isCreate = item.type === 'create';
+                    const Icon = isCreate ? Plus : FileText;
+                    return (
+                        <button
+                            key={isCreate ? '__create__' : item.docId}
+                            onClick={() => selectItem(index)}
+                            onMouseEnter={() => setSelectedIndex(index)}
+                            className={cn(
+                                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+                                isSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted/50',
+                            )}
+                        >
+                            <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            <span className="truncate">
+                                {isCreate ? (
+                                    <>Create “<span className="font-medium">{item.title}</span>”</>
+                                ) : (
+                                    item.title
+                                )}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+        );
+    },
+);
+
+NoteLinkList.displayName = 'NoteLinkList';

--- a/src/components/editor/plugins/NoteLink/index.ts
+++ b/src/components/editor/plugins/NoteLink/index.ts
@@ -1,0 +1,2 @@
+export { NoteLinkExtension, type NoteLinkItem, type NoteLinkOptions } from './NoteLinkExtension';
+export { NoteLinkList, type NoteLinkListRef } from './NoteLinkList';

--- a/src/hooks/useNoteTitleMap.ts
+++ b/src/hooks/useNoteTitleMap.ts
@@ -3,24 +3,22 @@ import { useLiveQuery } from './useLiveQuery';
 import { NOTE_TITLE_MAP_SQL, NOTE_ROW_KEY } from '@/lib/db';
 import type { NoteLinkResolution } from '@/components/editor/NoteLinkContext';
 
-type TitleRow = { doc_id: string; title: string; folder_id: string; status: number };
+type TitleRow = { doc_id: string; title: string; folder_id: string };
 
 /**
- * Live id → {title, folderId, status} map of every note, for resolving internal
- * link chips: current title (renames propagate), navigation target, and broken
- * state (id absent from the map). Backed by a PGlite live query so it stays fresh.
+ * Live id → {title, folderId} map of every ACTIVE note, for resolving internal
+ * link chips: current title (renames propagate) and navigation target. `isReady`
+ * distinguishes "still loading" from "target genuinely missing", so a valid chip
+ * isn't flashed as broken before the subscription's first emission.
  */
-export function useNoteTitleMap(): Map<string, NoteLinkResolution> {
-    const { data: rows } = useLiveQuery<TitleRow>(NOTE_TITLE_MAP_SQL, [], NOTE_ROW_KEY);
-    return useMemo(() => {
-        const map = new Map<string, NoteLinkResolution>();
+export function useNoteTitleMap(): { map: Map<string, NoteLinkResolution>; isReady: boolean } {
+    const { data: rows, isLoading } = useLiveQuery<TitleRow>(NOTE_TITLE_MAP_SQL, [], NOTE_ROW_KEY);
+    const map = useMemo(() => {
+        const m = new Map<string, NoteLinkResolution>();
         for (const r of rows) {
-            map.set(r.doc_id, {
-                title: r.title || 'Untitled',
-                folderId: r.folder_id,
-                status: Number(r.status) || 0,
-            });
+            m.set(r.doc_id, { title: r.title || 'Untitled', folderId: r.folder_id });
         }
-        return map;
+        return m;
     }, [rows]);
+    return { map, isReady: !isLoading };
 }

--- a/src/hooks/useNoteTitleMap.ts
+++ b/src/hooks/useNoteTitleMap.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import { useLiveQuery } from './useLiveQuery';
+import { NOTE_TITLE_MAP_SQL, NOTE_ROW_KEY } from '@/lib/db';
+import type { NoteLinkResolution } from '@/components/editor/NoteLinkContext';
+
+type TitleRow = { doc_id: string; title: string; folder_id: string; status: number };
+
+/**
+ * Live id → {title, folderId, status} map of every note, for resolving internal
+ * link chips: current title (renames propagate), navigation target, and broken
+ * state (id absent from the map). Backed by a PGlite live query so it stays fresh.
+ */
+export function useNoteTitleMap(): Map<string, NoteLinkResolution> {
+    const { data: rows } = useLiveQuery<TitleRow>(NOTE_TITLE_MAP_SQL, [], NOTE_ROW_KEY);
+    return useMemo(() => {
+        const map = new Map<string, NoteLinkResolution>();
+        for (const r of rows) {
+            map.set(r.doc_id, {
+                title: r.title || 'Untitled',
+                folderId: r.folder_id,
+                status: Number(r.status) || 0,
+            });
+        }
+        return map;
+    }, [rows]);
+}

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -8,7 +8,6 @@ import {
     upsertSyncRecord,
     deleteSyncRecord,
     updateSyncStatus,
-    saveDocumentUpdate,
     getTrashedNotes,
     getSearchIndexEntry,
     setNoteArchivalStatusLocal,
@@ -17,13 +16,13 @@ import {
     toNoteListEntry,
     type NoteListRow,
 } from '@/lib/db';
-import * as Y from 'yjs';
 import { getNewId } from '@/lib/utils';
 import type { NoteListEntry, SearchIndexEntry, DocumentMetadata } from '@/types';
 import { MAIN_FOLDER_ID } from '@/lib/homebase';
 import { useSyncService } from '@/hooks/useSyncService';
 import { formatGuidId } from '@homebase-id/js-lib/helpers';
 import { useLiveQuery } from './useLiveQuery';
+import { createNoteWithContent } from '@/lib/notes/createNoteWithContent';
 
 interface CreateNoteResult {
     docId: string;
@@ -188,57 +187,7 @@ export function useNotes() {
     });
 
     const createNoteWithContentMutation = useMutation<CreateNoteResult, Error, { title: string; content: string; folderId: string }>({
-        mutationFn: async ({ title, content, folderId }) => {
-            const docId = formatGuidId(getNewId());
-            const now = new Date().toISOString();
-
-            const metadata: DocumentMetadata = {
-                title: title || 'Untitled',
-                folderId: folderId || MAIN_FOLDER_ID,
-                tags: [],
-                timestamps: { created: now, modified: now },
-                excludeFromAI: false,
-                isPinned: false,
-            };
-
-            // 1. Create YJS Document with Content
-            const ydoc = new Y.Doc();
-            const fragment = ydoc.getXmlFragment('prosemirror');
-
-            // Create Tiptap JSON structure equivalent for a paragraph
-            // But YJS manipulation is lower level.
-            // We need to create XML elements.
-            const paragraph = new Y.XmlElement('paragraph');
-            if (content) {
-                const text = new Y.XmlText(content);
-                paragraph.push([text]);
-            }
-            fragment.push([paragraph]);
-
-            const updateBlob = Y.encodeStateAsUpdate(ydoc);
-
-            // 2. Save YJS Update
-            await saveDocumentUpdate(docId, updateBlob);
-
-            // 3. Save Search Index
-            await upsertSearchIndex({
-                docId,
-                title: metadata.title,
-                plainTextContent: content,
-                metadata,
-            });
-
-            // 4. Create Sync Record
-            await upsertSyncRecord({
-                localId: docId,
-                entityType: 'note',
-                syncStatus: 'pending',
-            });
-
-            ydoc.destroy();
-
-            return { docId, folderId: metadata.folderId };
-        },
+        mutationFn: createNoteWithContent,
     });
 
     // Soft delete — move a note to Trash (Homebase archivalStatus 2).

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -304,3 +304,11 @@ export function useNotesByFolder(folderId: string | undefined) {
 export function useCollaborativeNotes() {
     return useLiveNoteList(NOTE_LIST_SQL.collaborative, []);
 }
+
+/**
+ * Backlinks for the "Linked mentions" panel — active notes whose
+ * metadata.linkedNoteIds contains this note's id.
+ */
+export function useBacklinks(noteId: string | undefined) {
+    return useLiveNoteList(NOTE_LIST_SQL.backlinks, [noteId ?? ''], !!noteId);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -195,6 +195,34 @@ body {
   opacity: 0.7;
 }
 
+/* Internal note links ([[) — rendered as inline chips */
+.note-link-wrapper {
+  display: inline;
+  white-space: nowrap;
+}
+
+.note-link {
+  display: inline;
+  color: var(--primary);
+  font-weight: 500;
+  text-decoration: none;
+  border-radius: 0.25rem;
+  padding: 0 0.15rem;
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.note-link:hover {
+  background: color-mix(in srgb, var(--primary) 20%, transparent);
+}
+
+.note-link--broken {
+  color: var(--muted-foreground);
+  background: color-mix(in srgb, var(--muted-foreground) 12%, transparent);
+  cursor: default;
+}
+
 .prose blockquote {
   border-left: 3px solid var(--border);
   padding-left: 1rem;

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -37,9 +37,15 @@ export const NOTE_LIST_SQL = {
     trashed: `${NOTE_LIST_SELECT} WHERE COALESCE((metadata->>'archivalStatus')::int, 0) = 2 ${MODIFIED_DESC}`,
     archived: `${NOTE_LIST_SELECT} WHERE COALESCE((metadata->>'archivalStatus')::int, 0) = 1 ${MODIFIED_DESC}`,
     byTag: `${NOTE_LIST_SELECT} WHERE metadata->'tags' ? $1 AND ${ACTIVE_NOTES_FILTER} ORDER BY (metadata->>'isPinned')::boolean DESC NULLS LAST, updated_at DESC`,
+    // Backlinks: active notes whose metadata.linkedNoteIds array contains $1.
+    // Uses the same jsonb `?` element-exists operator as the tag filter.
+    backlinks: `${NOTE_LIST_SELECT} WHERE metadata->'linkedNoteIds' ? $1 AND ${ACTIVE_NOTES_FILTER} ${MODIFIED_DESC}`,
 } as const;
 
 export const FOLDERS_SQL = `SELECT id, name, created_at FROM folders ORDER BY name ASC`;
+
+// All notes' id → title/folder/status, for live-resolving internal-link titles.
+export const NOTE_TITLE_MAP_SQL = `SELECT doc_id, title, metadata->>'folderId' AS folder_id, COALESCE((metadata->>'archivalStatus')::int, 0) AS status FROM search_index`;
 
 
 
@@ -269,6 +275,43 @@ export async function getNotesForListByFolder(folderId: string): Promise<NoteLis
            AND ${ACTIVE_NOTES_FILTER}
          ORDER BY (metadata->'timestamps'->>'modified')::timestamp DESC NULLS LAST`,
         [folderId]
+    );
+    return result.rows.map(toNoteListEntry);
+}
+
+/**
+ * Search active notes by title substring, for the `[[` note-link picker.
+ * Excludes the current note (self-link) and archived/trashed notes. An empty
+ * query returns the most-recently-modified active notes.
+ */
+export async function searchNotesByTitle(
+    query: string,
+    excludeId?: string,
+    limit = 8,
+): Promise<NoteListEntry[]> {
+    const db = await getDatabase();
+    const trimmed = query.trim();
+
+    if (trimmed) {
+        const result = await db.query<NoteListRow>(
+            `${NOTE_LIST_SELECT}
+             WHERE title ILIKE '%' || $1 || '%'
+               AND ${ACTIVE_NOTES_FILTER}
+               AND ($2::uuid IS NULL OR doc_id <> $2)
+             ORDER BY title ASC
+             LIMIT $3`,
+            [trimmed, excludeId ?? null, limit],
+        );
+        return result.rows.map(toNoteListEntry);
+    }
+
+    const result = await db.query<NoteListRow>(
+        `${NOTE_LIST_SELECT}
+         WHERE ${ACTIVE_NOTES_FILTER}
+           AND ($1::uuid IS NULL OR doc_id <> $1)
+         ${MODIFIED_DESC}
+         LIMIT $2`,
+        [excludeId ?? null, limit],
     );
     return result.rows.map(toNoteListEntry);
 }

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -44,8 +44,10 @@ export const NOTE_LIST_SQL = {
 
 export const FOLDERS_SQL = `SELECT id, name, created_at FROM folders ORDER BY name ASC`;
 
-// All notes' id → title/folder/status, for live-resolving internal-link titles.
-export const NOTE_TITLE_MAP_SQL = `SELECT doc_id, title, metadata->>'folderId' AS folder_id, COALESCE((metadata->>'archivalStatus')::int, 0) AS status FROM search_index`;
+// Active notes' id → title/folder, for live-resolving internal-link titles.
+// Active-only: links to archived/trashed notes resolve as "broken" rather than
+// navigating to an editor route that can't load them.
+export const NOTE_TITLE_MAP_SQL = `SELECT doc_id, title, metadata->>'folderId' AS folder_id FROM search_index WHERE ${ACTIVE_NOTES_FILTER}`;
 
 
 
@@ -120,10 +122,17 @@ export async function updateSearchIndexMetadata(
     metadata: DocumentMetadata,
 ): Promise<void> {
     const db = await getDatabase();
+    // `linkedNoteIds` is editor-owned (written only by the content-save path).
+    // Metadata-only writes (title, pin, tags, collaboration) must not clobber it
+    // from a stale snapshot, so preserve the row's existing value via a jsonb overlay.
     await db.query(
         `UPDATE search_index
          SET title = $2,
-             metadata = $3,
+             metadata = CASE
+               WHEN metadata ? 'linkedNoteIds'
+               THEN $3::jsonb || jsonb_build_object('linkedNoteIds', metadata->'linkedNoteIds')
+               ELSE $3::jsonb
+             END,
              search_vector = setweight(to_tsvector('english', COALESCE($2, '')), 'A') ||
                              setweight(to_tsvector('english', COALESCE(plain_text_content, '')), 'B'),
              updated_at = CURRENT_TIMESTAMP

--- a/src/lib/editor/extractNoteLinkIds.ts
+++ b/src/lib/editor/extractNoteLinkIds.ts
@@ -1,0 +1,22 @@
+import type { JSONContent } from '@tiptap/core';
+
+/**
+ * Walk a Tiptap document (editor.getJSON()) and collect the unique target
+ * note ids of every `noteLink` node. Used on save to populate
+ * `DocumentMetadata.linkedNoteIds`, which powers the backlinks live query.
+ */
+export function extractNoteLinkIds(doc: JSONContent | null | undefined): string[] {
+    const ids = new Set<string>();
+
+    const walk = (node: JSONContent | null | undefined): void => {
+        if (!node) return;
+        if (node.type === 'noteLink') {
+            const noteId = node.attrs?.noteId;
+            if (typeof noteId === 'string' && noteId) ids.add(noteId);
+        }
+        node.content?.forEach(walk);
+    };
+
+    walk(doc);
+    return [...ids];
+}

--- a/src/lib/importexport/index.ts
+++ b/src/lib/importexport/index.ts
@@ -431,6 +431,12 @@ function xmlElementToMarkdown(element: Y.XmlElement): string {
             return '```\n' + content + '\n```';
         case 'blockquote':
             return '> ' + content;
+        case 'noteLink': {
+            // Internal note link → stable markdown form `[label](note:<id>)`.
+            const label = element.getAttribute('label') || 'note';
+            const noteId = element.getAttribute('noteId');
+            return noteId ? `[${label}](note:${noteId})` : label;
+        }
         default:
             return content;
     }

--- a/src/lib/notes/createNoteWithContent.ts
+++ b/src/lib/notes/createNoteWithContent.ts
@@ -1,0 +1,66 @@
+import * as Y from 'yjs';
+import { getNewId } from '@/lib/utils';
+import { formatGuidId } from '@homebase-id/js-lib/helpers';
+import { MAIN_FOLDER_ID } from '@/lib/homebase';
+import { saveDocumentUpdate, upsertSearchIndex, upsertSyncRecord } from '@/lib/db';
+import type { DocumentMetadata } from '@/types';
+
+export interface CreateNoteResult {
+    docId: string;
+    folderId: string;
+}
+
+/**
+ * Create a note with initial plain-text content, locally-first: write the Yjs
+ * document, the search index, and a pending sync record. Shared by the
+ * useNotes mutation and the `[[` create-on-the-fly flow so neither has to
+ * subscribe to the note list just to create.
+ */
+export async function createNoteWithContent({
+    title,
+    content,
+    folderId,
+}: {
+    title: string;
+    content: string;
+    folderId: string;
+}): Promise<CreateNoteResult> {
+    const docId = formatGuidId(getNewId());
+    const now = new Date().toISOString();
+
+    const metadata: DocumentMetadata = {
+        title: title || 'Untitled',
+        folderId: folderId || MAIN_FOLDER_ID,
+        tags: [],
+        timestamps: { created: now, modified: now },
+        excludeFromAI: false,
+        isPinned: false,
+    };
+
+    // Build the Yjs document with the initial paragraph content.
+    const ydoc = new Y.Doc();
+    const fragment = ydoc.getXmlFragment('prosemirror');
+    const paragraph = new Y.XmlElement('paragraph');
+    if (content) {
+        paragraph.push([new Y.XmlText(content)]);
+    }
+    fragment.push([paragraph]);
+    const updateBlob = Y.encodeStateAsUpdate(ydoc);
+
+    await saveDocumentUpdate(docId, updateBlob);
+    await upsertSearchIndex({
+        docId,
+        title: metadata.title,
+        plainTextContent: content,
+        metadata,
+    });
+    await upsertSyncRecord({
+        localId: docId,
+        entityType: 'note',
+        syncStatus: 'pending',
+    });
+
+    ydoc.destroy();
+
+    return { docId, folderId: metadata.folderId };
+}

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -12,6 +12,7 @@ import { SyncStatus } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft } from "lucide-react";
 import { CollaborativePopover } from '@/components/editor/CollaborativePopover';
+import { LinkedMentions } from "@/components/editor/LinkedMentions";
 import { cn } from "@/lib/utils";
 import { useSyncService, useKeyboardShortcuts, useDeviceType } from "@/hooks";
 import { usePeerNoteWebsocket } from "@/hooks/usePeerNoteWebsocket";
@@ -129,6 +130,14 @@ function EditorLayout({
               : "max-w-5xl md:px-12"
           )}
         />
+        <div
+          className={cn(
+            "mx-auto px-6 pb-24 md:pb-8",
+            focusMode ? "max-w-2xl md:px-8" : "max-w-5xl md:px-12"
+          )}
+        >
+          <LinkedMentions noteId={noteId} />
+        </div>
       </div>
     </div>
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export interface DocumentMetadata {
     excludeFromAI: boolean;
     isPinned?: boolean;
     isPublic?: boolean;      // Shared via public link (ACL = Anonymous)
+    linkedNoteIds?: string[]; // docIds this note links to via [[ internal links (powers backlinks)
     archivalStatus?: number; // Homebase ArchivalStatus: 0 active, 2 trashed (Removed)
     // Collaboration fields
     isCollaborative?: boolean;


### PR DESCRIPTION
## What

Wiki-style internal links (`[[`) + a reactive **backlinks** panel — the foundation for backlinks/graph view.

Spec: `docs/superpowers/specs/2026-06-06-internal-note-links-design.md` (local).

## How
- **`noteLink`** inline atom node (stable `noteId` + `label` snapshot). React node view resolves the displayed title **live** from a note-title map, so renames propagate and deleted/foreign targets render muted ("⚠ not found").
- **`[[` suggestion** (`NoteLinkExtension`) reusing the slash-command plumbing (`@tiptap/suggestion` + `ReactRenderer` + `tippy`): async title search (`searchNotesByTitle`, excludes self + archived/trashed) + a **"Create '<query>'"** action that creates a note and links it inline.
- **Backlinks, no new table:** `metadata.linkedNoteIds` is recomputed on save (`extractNoteLinkIds`), and "Linked mentions" is a **PGlite live query** (`NOTE_LIST_SQL.backlinks` → `metadata->'linkedNoteIds' ? $1`, same `?` operator as the tag filter) at the bottom of the editor — reactive.
- **`useNoteTitleMap`** — live id→{title,folderId,status} map powering chip title resolution + navigation via `NoteLinkContext`.
- Markdown export maps `noteLink` → `[label](note:<id>)`.

## Tests
TDD on the pure/DB seams (13 new tests): `extractNoteLinkIds`, `searchNotesByTitle`, and the backlinks live query through a live-enabled PGlite. Node view / popup / editor wiring are covered by the runtime smoke test (no RTL in this project).

- `npm run build` ✅ · `npm run lint` ✅ (0 suppressions) · `npx vitest run` ✅ **272 passing**

## ⚠️ Draft — pending review + runtime smoke test
- [ ] Multi-agent code review (in progress)
- [ ] Runtime: type `[[`, pick a note + create-on-the-fly, click a chip, rename a target (title updates), delete a target (broken chip), backlinks panel populates live

🤖 Generated with [Claude Code](https://claude.com/claude-code)