### PR TITLE
perf(startup): cut cold start ~12s→~2s (live.query + lazy pg_trgm + schema gating)

### DIFF
--- a/src/__tests__/lazyTrigramSearch.test.ts
+++ b/src/__tests__/lazyTrigramSearch.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for ensureTrigramSearch — the lazy pg_trgm initializer that defers
+ * the ~1-2s extension load out of app boot to first search. We verify the
+ * run-once caching and retry-after-failure contract with a mock db (the SQL
+ * itself is covered by the search integration tests).
+ *
+ * ensureTrigramSearch caches its promise at module scope, so each test imports a
+ * fresh module instance via vi.resetModules().
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('ensureTrigramSearch', () => {
+  it('runs the extension + index setup exactly once across repeated calls', async () => {
+    const { ensureTrigramSearch } = await import('@/lib/db/pglite');
+    const exec = vi.fn().mockResolvedValue(undefined);
+    const db = { exec } as unknown as import('@electric-sql/pglite').PGliteInterface;
+
+    await ensureTrigramSearch(db);
+    await ensureTrigramSearch(db);
+    await ensureTrigramSearch(db);
+
+    // Extension + both indexes batched into a single exec, run once total.
+    expect(exec).toHaveBeenCalledTimes(1);
+    const sql = exec.mock.calls[0][0] as string;
+    expect(sql).toContain('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+    expect(sql).toContain('idx_search_title_trgm');
+    expect(sql).toContain('idx_search_content_trgm');
+  });
+
+  it('returns the same in-flight promise to concurrent callers', async () => {
+    const { ensureTrigramSearch } = await import('@/lib/db/pglite');
+    const exec = vi.fn().mockResolvedValue(undefined);
+    const db = { exec } as unknown as import('@electric-sql/pglite').PGliteInterface;
+
+    await Promise.all([ensureTrigramSearch(db), ensureTrigramSearch(db)]);
+
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the cache on failure so the next call retries', async () => {
+    const { ensureTrigramSearch } = await import('@/lib/db/pglite');
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('extension unavailable')) // first attempt fails
+      .mockResolvedValue(undefined); // retry succeeds
+    const db = { exec } as unknown as import('@electric-sql/pglite').PGliteInterface;
+
+    await expect(ensureTrigramSearch(db)).rejects.toThrow('extension unavailable');
+    await ensureTrigramSearch(db); // should retry rather than stay wedged
+
+    // 1 failed exec + 1 on the successful retry.
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/noteCounts.test.ts
+++ b/src/__tests__/noteCounts.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Validates NOTE_COUNTS_SQL — the single-row counts query that backs the sidebar
+ * trash/archive/shared badges (replacing three full-list live subscriptions at
+ * boot). The filters must mirror NOTE_LIST_SQL.{trashed,archived,collaborative},
+ * since wrong filters mean wrong badge numbers.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import { createTestDatabase, closeTestDatabase, resetTestDatabase } from './testDb';
+import { NOTE_COUNTS_SQL, type NoteCountsRow } from '@/lib/db';
+
+function generateTestId(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+async function insertNote(db: PGlite, metadata: Record<string, unknown>) {
+  await db.query(
+    `INSERT INTO search_index (doc_id, title, plain_text_content, metadata) VALUES ($1, 'T', '', $2)`,
+    [generateTestId(), JSON.stringify(metadata)],
+  );
+}
+
+describe('NOTE_COUNTS_SQL', () => {
+  let db: PGlite;
+
+  beforeAll(async () => {
+    db = await createTestDatabase();
+  });
+  afterAll(async () => {
+    await closeTestDatabase();
+  });
+  beforeEach(async () => {
+    await resetTestDatabase();
+  });
+
+  it('returns zeros on an empty table', async () => {
+    const res = await db.query<NoteCountsRow>(NOTE_COUNTS_SQL);
+    expect(res.rows[0]).toEqual({ trashed: 0, archived: 0, collaborative: 0 });
+  });
+
+  it('counts trashed / archived / collaborative and ignores active notes', async () => {
+    await insertNote(db, { folderId: 'main' }); // active — not counted
+    await insertNote(db, { folderId: 'main', archivalStatus: 2 }); // trashed
+    await insertNote(db, { folderId: 'main', archivalStatus: 2 }); // trashed
+    await insertNote(db, { folderId: 'main', archivalStatus: 1 }); // archived
+    await insertNote(db, { folderId: 'main', isCollaborative: true }); // collaborative (active)
+    // collaborative but trashed → counts as trashed, NOT as collaborative
+    await insertNote(db, { folderId: 'main', isCollaborative: true, archivalStatus: 2 });
+
+    const res = await db.query<NoteCountsRow>(NOTE_COUNTS_SQL);
+    expect(res.rows[0]).toEqual({ trashed: 3, archived: 1, collaborative: 1 });
+  });
+});

--- a/src/hooks/useLiveQuery.ts
+++ b/src/hooks/useLiveQuery.ts
@@ -15,13 +15,19 @@ interface LiveEntry {
 const registry = new Map<string, LiveEntry>();
 
 /**
- * Subscribe to a PGlite live (incremental) query. PGlite is the reactive source:
- * any write to the underlying table re-emits results, so the UI updates
+ * Subscribe to a PGlite live query. PGlite is the reactive source: any write to
+ * the underlying table re-emits the full result set, so the UI updates
  * progressively (e.g. notes streaming in during sync) with no manual invalidation.
+ *
+ * Uses db.live.query (re-run on change) rather than incrementalQuery (row-level
+ * diffing): incrementalQuery's per-subscription setup costs ~1.2s on the single
+ * worker thread, and the boot path opens several subscriptions at once. live.query
+ * sets up ~2.6x faster, which dominates startup; these list result sets are small
+ * enough that re-running on change is cheap.
  *
  * @param sql     query text
  * @param params  positional params (compared by value, not identity)
- * @param rowKey  unique column used by incrementalQuery for row diffing (e.g. 'doc_id')
+ * @param rowKey  discriminator folded into the subscription cache key (e.g. 'doc_id')
  * @param enabled when false, no subscription is created and the result is empty
  */
 export function useLiveQuery<T>(
@@ -38,12 +44,10 @@ export function useLiveQuery<T>(
   // exhaustive-deps. Refs are synced in an effect — never written during render.
   const sqlRef = useRef(sql);
   const paramsRef = useRef(params);
-  const rowKeyRef = useRef(rowKey);
   useEffect(() => {
     sqlRef.current = sql;
     paramsRef.current = params;
-    rowKeyRef.current = rowKey;
-  }, [sql, params, rowKey]);
+  }, [sql, params]);
 
   const [data, setData] = useState<T[]>(() => {
     const e = enabled ? registry.get(cacheKey) : undefined;
@@ -104,10 +108,9 @@ export function useLiveQuery<T>(
       void (async () => {
         try {
           const db = await getLiveDatabase();
-          const lq = await db.live.incrementalQuery(
+          const lq = await db.live.query(
             sqlRef.current,
             paramsRef.current as unknown[],
-            rowKeyRef.current,
             (res) => {
               // Drop emissions for an entry that was discarded and replaced.
               if (registry.get(cacheKey) !== myEntry) return;
@@ -145,7 +148,7 @@ export function useLiveQuery<T>(
       e.refs -= 1;
       if (e.refs <= 0) {
         registry.delete(cacheKey);
-        void e.unsubscribe?.();
+        void e.unsubscribe?.()?.catch(() => {});
       }
     };
   }, [cacheKey, enabled]);

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -14,8 +14,10 @@ import {
     setNoteArchivalStatusLocal,
     NOTE_LIST_SQL,
     NOTE_ROW_KEY,
+    NOTE_COUNTS_SQL,
     toNoteListEntry,
     type NoteListRow,
+    type NoteCountsRow,
 } from '@/lib/db';
 import * as Y from 'yjs';
 import { getNewId } from '@/lib/utils';
@@ -278,17 +280,35 @@ export function useNotes() {
 }
 
 /**
- * Query hook for the Trash view — notes with archivalStatus 2 (Removed).
+ * Live counts for the sidebar badges (trash / archive / shared). A single
+ * subscription instead of three full-list subscriptions at boot — the full lists
+ * are only subscribed when their view is actually open (see the `enabled` params
+ * on useTrashedNotes / useArchivedNotes / useCollaborativeNotes).
  */
-export function useTrashedNotes() {
-    return useLiveNoteList(NOTE_LIST_SQL.trashed, []);
+export function useNoteCounts(): NoteCountsRow {
+    const { data } = useLiveQuery<NoteCountsRow>(NOTE_COUNTS_SQL, [], 'note-counts');
+    const row = data[0];
+    return {
+        trashed: row?.trashed ?? 0,
+        archived: row?.archived ?? 0,
+        collaborative: row?.collaborative ?? 0,
+    };
+}
+
+/**
+ * Query hook for the Trash view — notes with archivalStatus 2 (Removed).
+ * Pass enabled=false to skip the subscription when the Trash view isn't open.
+ */
+export function useTrashedNotes(enabled: boolean = true) {
+    return useLiveNoteList(NOTE_LIST_SQL.trashed, [], enabled);
 }
 
 /**
  * Query hook for the Archive view — notes with archivalStatus 1 (Archived).
+ * Pass enabled=false to skip the subscription when the Archive view isn't open.
  */
-export function useArchivedNotes() {
-    return useLiveNoteList(NOTE_LIST_SQL.archived, []);
+export function useArchivedNotes(enabled: boolean = true) {
+    return useLiveNoteList(NOTE_LIST_SQL.archived, [], enabled);
 }
 
 /**
@@ -301,6 +321,6 @@ export function useNotesByFolder(folderId: string | undefined) {
     return useLiveNoteList(NOTE_LIST_SQL.byFolder, [folderId ?? ''], enabled);
 }
 
-export function useCollaborativeNotes() {
-    return useLiveNoteList(NOTE_LIST_SQL.collaborative, []);
+export function useCollaborativeNotes(enabled: boolean = true) {
+    return useLiveNoteList(NOTE_LIST_SQL.collaborative, [], enabled);
 }

--- a/src/layouts/JournalLayout.tsx
+++ b/src/layouts/JournalLayout.tsx
@@ -50,6 +50,7 @@ import type { NoteListEntry } from "@/types";
 import {
   useNotes,
   useNotesByFolder,
+  useNoteCounts,
   useCollaborativeNotes,
   useTrashedNotes,
   useArchivedNotes,
@@ -229,10 +230,16 @@ export default function JournalLayout() {
 
   const { data: filteredNotes = [], isLoading: isFilteredNotesLoading } =
     useNotesByFolder(folderId);
+  // Sidebar badge counts come from one lightweight live query. The full
+  // trash/archive/shared lists are only subscribed when their view is open, so
+  // they don't each spin up a live subscription at boot.
+  const counts = useNoteCounts();
   const { data: collaborativeNotes = [], isLoading: isCollaborativeLoading } =
-    useCollaborativeNotes();
-  const { data: trashedNotes = [], isLoading: isTrashLoading } = useTrashedNotes();
-  const { data: archivedNotes = [], isLoading: isArchivedLoading } = useArchivedNotes();
+    useCollaborativeNotes(folderId === "shared");
+  const { data: trashedNotes = [], isLoading: isTrashLoading } =
+    useTrashedNotes(folderId === "trash");
+  const { data: archivedNotes = [], isLoading: isArchivedLoading } =
+    useArchivedNotes(folderId === "archive");
 
   // Trash / Archive actions — stable handlers with user-visible error feedback.
   const handleRestoreFromTrash = useCallback(
@@ -376,12 +383,12 @@ export default function JournalLayout() {
           }}
           onCreateFolder={() => setShowCreateFolder(true)}
           onDeleteFolder={(id) => deleteFolder(id)}
-          collaborativeCount={collaborativeNotes.length}
+          collaborativeCount={counts.collaborative}
           onSelectShared={() => navigate("/shared")}
           onSelectTrash={() => navigate("/trash")}
-          trashCount={trashedNotes.length}
+          trashCount={counts.trashed}
           onSelectArchive={() => navigate("/archive")}
-          archivedCount={archivedNotes.length}
+          archivedCount={counts.archived}
           onSearch={() => setShowSearch(true)}
           onSettings={() => setShowSettings(true)}
           onLogout={handleLogout}
@@ -737,12 +744,12 @@ export default function JournalLayout() {
       <ExtendPermissionDialog
         appId={JOURNAL_APP_ID}
         appName={JOURNAL_APP_NAME}
-        drives={collaborativeNotes.length > 0 ? COLLAB_DRIVES : BASE_DRIVES}
+        drives={counts.collaborative > 0 ? COLLAB_DRIVES : BASE_DRIVES}
         circleDrives={
-          collaborativeNotes.length > 0 ? COLLAB_DRIVES : NO_PERMISSIONS
+          counts.collaborative > 0 ? COLLAB_DRIVES : NO_PERMISSIONS
         }
         permissions={
-          collaborativeNotes.length > 0
+          counts.collaborative > 0
             ? COLLABORATION_PERMISSIONS
             : NO_PERMISSIONS
         }

--- a/src/lib/db/pglite.ts
+++ b/src/lib/db/pglite.ts
@@ -12,8 +12,35 @@ import {
 
 const DATA_DIR = 'idb://journal-db';
 const PGLITE_VERSION = '0.4';
+// Bump whenever a new statement is added to runMigrations().
+const SCHEMA_VERSION = '1';
 
 let dbPromise: Promise<PGliteInterface> | null = null;
+
+// Lazily enabled the first time fuzzy search runs — see ensureTrigramSearch().
+let trigramSearchPromise: Promise<void> | null = null;
+
+/**
+ * Enable pg_trgm and its GIN indexes on demand. Deferred out of the boot path
+ * because loading the extension costs ~1–2s per launch and only fuzzy search
+ * (advancedSearch) needs it. Idempotent and run-once per app load; a failure
+ * clears the cached promise so the next search retries.
+ */
+export function ensureTrigramSearch(db: PGliteInterface): Promise<void> {
+  if (!trigramSearchPromise) {
+    trigramSearchPromise = (async () => {
+      await db.exec(`
+        CREATE EXTENSION IF NOT EXISTS pg_trgm;
+        CREATE INDEX IF NOT EXISTS idx_search_title_trgm ON search_index USING GIN(title gin_trgm_ops);
+        CREATE INDEX IF NOT EXISTS idx_search_content_trgm ON search_index USING GIN(plain_text_content gin_trgm_ops);
+      `);
+    })().catch((err) => {
+      trigramSearchPromise = null;
+      throw err;
+    });
+  }
+  return trigramSearchPromise;
+}
 
 export function getDatabase(): Promise<PGliteInterface> {
   if (!dbPromise) {
@@ -78,13 +105,25 @@ async function initDatabase(): Promise<PGliteInterface> {
 async function initializeSchema(database: PGliteInterface): Promise<void> {
   console.log('[DB Schema] Starting schema initialization...');
 
-  // Enable pg_trgm extension for fuzzy/trigram matching
-  // This must happen BEFORE any queries that use it
-  try {
-    await database.exec(`CREATE EXTENSION IF NOT EXISTS pg_trgm;`);
-    console.log('[DB Schema] pg_trgm extension enabled');
-  } catch (error) {
-    console.warn('[DB Schema] Could not enable pg_trgm:', error);
+  // NOTE: pg_trgm is no longer enabled here — loading it costs ~1–2s and nothing
+  // on the boot path uses trigram matching. It's enabled lazily on first search
+  // via ensureTrigramSearch().
+
+  // The applied schema revision lives INSIDE the database (not localStorage) so
+  // it can never desync from the schema it guards: if the data dir is wiped or
+  // evicted, this marker is gone too and full setup re-runs. Once a revision is
+  // applied we skip BOTH the base-table DDL and the migration chain — they're
+  // idempotent, but re-running them costs several hundred ms on every launch.
+  // Bump SCHEMA_VERSION to force a re-run after a schema change.
+  await database.exec(
+    `CREATE TABLE IF NOT EXISTS schema_meta (id INTEGER PRIMARY KEY, version TEXT NOT NULL);`,
+  );
+  const applied = await database.query<{ version: string }>(
+    `SELECT version FROM schema_meta WHERE id = 1`,
+  );
+  if (applied.rows[0]?.version === SCHEMA_VERSION) {
+    console.log('[DB Schema] Schema up to date, skipping schema setup');
+    return;
   }
 
   await database.exec(`
@@ -209,20 +248,19 @@ async function initializeSchema(database: PGliteInterface): Promise<void> {
 
   console.log('[DB Schema] Base tables created');
 
-  // Run migrations for existing databases
   await runMigrations(database);
+  await database.query(
+    `INSERT INTO schema_meta (id, version) VALUES (1, $1)
+     ON CONFLICT (id) DO UPDATE SET version = $1`,
+    [SCHEMA_VERSION],
+  );
 }
 
 async function runMigrations(database: PGliteInterface): Promise<void> {
   console.log('[DB Migration] Starting migrations...');
 
-  // Ensure pg_trgm extension is enabled (for existing dbs)
-  try {
-    await database.exec(`CREATE EXTENSION IF NOT EXISTS pg_trgm;`);
-    console.log('[DB Migration] pg_trgm extension enabled');
-  } catch (error) {
-    console.warn('[DB Migration] Could not enable pg_trgm extension:', error);
-  }
+  // pg_trgm and its trigram indexes are enabled lazily on first search via
+  // ensureTrigramSearch() — intentionally not created here.
 
   // Add vector_embedding column if it doesn't exist
   try {
@@ -255,26 +293,16 @@ async function runMigrations(database: PGliteInterface): Promise<void> {
     console.warn('[DB Migration] Could not create FTS index:', error);
   }
 
-  // Create GIN index for trigram similarity on title
+  // Drop any pre-existing trigram indexes. They're now created lazily on first
+  // search (ensureTrigramSearch); leaving them would force every search_index
+  // write to load pg_trgm at boot, defeating the deferral. DROP doesn't need the
+  // extension loaded, and on a fresh db these are no-ops.
   try {
-    await database.exec(`
-      CREATE INDEX IF NOT EXISTS idx_search_title_trgm 
-      ON search_index USING GIN(title gin_trgm_ops);
-    `);
-    console.log('[DB Migration] Title trigram index ensured');
+    await database.exec(`DROP INDEX IF EXISTS idx_search_title_trgm;`);
+    await database.exec(`DROP INDEX IF EXISTS idx_search_content_trgm;`);
+    console.log('[DB Migration] Legacy trigram indexes dropped (now lazy)');
   } catch (error) {
-    console.warn('[DB Migration] Could not create title trigram index:', error);
-  }
-
-  // Create GIN index for trigram similarity on content
-  try {
-    await database.exec(`
-      CREATE INDEX IF NOT EXISTS idx_search_content_trgm 
-      ON search_index USING GIN(plain_text_content gin_trgm_ops);
-    `);
-    console.log('[DB Migration] Content trigram index ensured');
-  } catch (error) {
-    console.warn('[DB Migration] Could not create content trigram index:', error);
+    console.warn('[DB Migration] Could not drop legacy trigram indexes:', error);
   }
 
   // Create BTREE expression index on metadata folderId for folder filtering

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -1,5 +1,5 @@
 import { MAIN_FOLDER_ID } from '../homebase';
-import { getDatabase } from './pglite';
+import { getDatabase, ensureTrigramSearch } from './pglite';
 import type { SearchIndexEntry, NoteListEntry, Folder, DocumentMetadata, SyncRecord, PendingImageUpload, SyncError, AdvancedSearchResult } from '@/types';
 
 // Notes with archivalStatus 2 (Homebase "Removed") live in the Trash — exclude them
@@ -38,6 +38,18 @@ export const NOTE_LIST_SQL = {
     archived: `${NOTE_LIST_SELECT} WHERE COALESCE((metadata->>'archivalStatus')::int, 0) = 1 ${MODIFIED_DESC}`,
     byTag: `${NOTE_LIST_SELECT} WHERE metadata->'tags' ? $1 AND ${ACTIVE_NOTES_FILTER} ORDER BY (metadata->>'isPinned')::boolean DESC NULLS LAST, updated_at DESC`,
 } as const;
+
+// Single-row counts for the sidebar badges (trash / archive / shared). One live
+// subscription replaces the three full-list subscriptions that previously ran at
+// boot just to show counts. Filters mirror NOTE_LIST_SQL.{trashed,archived,collaborative}.
+export const NOTE_COUNTS_SQL = `
+    SELECT
+        (COUNT(*) FILTER (WHERE COALESCE((metadata->>'archivalStatus')::int, 0) = 2))::int AS trashed,
+        (COUNT(*) FILTER (WHERE COALESCE((metadata->>'archivalStatus')::int, 0) = 1))::int AS archived,
+        (COUNT(*) FILTER (WHERE (metadata->>'isCollaborative')::boolean = true AND ${ACTIVE_NOTES_FILTER}))::int AS collaborative
+    FROM search_index`;
+
+export type NoteCountsRow = { trashed: number; archived: number; collaborative: number };
 
 export const FOLDERS_SQL = `SELECT id, name, created_at FROM folders ORDER BY name ASC`;
 
@@ -382,6 +394,10 @@ export async function advancedSearch(query: string): Promise<AdvancedSearchResul
     const likePattern = `%${trimmedQuery.toLowerCase()}%`;
 
     try {
+        // pg_trgm + its indexes are loaded lazily (deferred out of app boot).
+        // If this fails the catch below falls back to plain LIKE search.
+        await ensureTrigramSearch(db);
+
         const result = await db.query<{
             doc_id: string;
             title: string;


### PR DESCRIPTION
## Summary

App cold start was **~5–7s (up to ~12s on a cold cache)**. I instrumented the boot phases, found the costs were almost entirely in **PGlite live-query setup** and **per-boot schema work** (not the data or queries — the note-list query returned in ~120ms), and fixed the top contributors. Measured result: **~12s → ~3s in dev, ~1.5–2s in prod** (dev carries a ~2× React StrictMode tax that prod doesn't).

### Measured boot breakdown (dev, before → after)
| phase | before | after |
|---|---|---|
| `pg_trgm` extension load | ~1200ms | **0** (lazy) |
| migration chain | ~500ms | **0** (gated) |
| base-table DDL | ~668ms | **0** (gated) |
| first live results | ~8900ms | **~2200ms** |

## Changes

1. **`useLiveQuery`: `incrementalQuery` → `live.query`.** Measured `incrementalQuery` setup at ~1.2s/subscription vs ~0.46s for `live.query`, with no data. Row-level diffing wasn't needed — these are list-sized result sets and React keys handle row identity. `rowKey` is retained purely as a cache-key discriminator.
2. **Defer `pg_trgm` to first search.** The extension + its trigram GIN indexes are no longer loaded at boot; a run-once `ensureTrigramSearch()` enables them on the first fuzzy search (`advancedSearch`), which already falls back to LIKE if it fails. A one-time migration **drops** the legacy trigram indexes so boot-time writes don't implicitly reload the extension.
3. **Version-gate schema setup.** Base-table DDL + the migration chain now run once per `SCHEMA_VERSION` instead of every launch. The version marker lives **inside the database** (`schema_meta` table), so it can never desync from the schema it guards — an IndexedDB wipe also clears the marker and triggers full re-setup.
4. **Consolidate off-screen subscriptions.** The sidebar trash/archive/shared badges are now fed by **one** live counts query (`NOTE_COUNTS_SQL`) instead of three always-on full-list subscriptions; the full lists subscribe only when their view is open (**6 → 4 boot subscriptions**).

## Tests
- `lazyTrigramSearch.test.ts` — run-once + retry-on-failure contract for `ensureTrigramSearch`.
- `noteCounts.test.ts` — `NOTE_COUNTS_SQL` filter parity with the list queries (incl. collaborative-but-trashed edge case).
- Full suite green: **264 passed**; build + lint clean.

## Code review
Ran a high-effort multi-agent review (7 angles). Fixes applied from it:
- Schema version moved from localStorage **into the DB** (the headline finding — localStorage/IndexedDB could desync and wedge the app with an empty DB).
- `NOTE_COUNTS_SQL` now reuses the shared `ACTIVE_NOTES_FILTER` (no badge/list drift).
- `ensureTrigramSearch` batched into one `exec`.
- Guarded the fire-and-forget teardown `unsubscribe()` against unhandled rejection.

## Known tradeoffs (follow-ups, not blockers)
- Forgetting to bump `SCHEMA_VERSION` when adding a migration silently skips it for existing users (inherent to version-gating; documented in code).
- A transient (rare) failure of a perf index build during the one-time migration is recorded as applied; impact is degraded-but-working search (LIKE/seq-scan fallback), not a crash.
- First fuzzy search after upgrade rebuilds the trigram GIN indexes once (then persists) — a deliberate boot→first-search cost shift; could be warmed in idle time later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)