### PR TITLE
fix(editor): delete stray empty paragraph at the start of the document

### DIFF
--- a/src/__tests__/editorBackspace.test.ts
+++ b/src/__tests__/editorBackspace.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression: a stray empty paragraph at the very START of the document (above a
+ * list / horizontal rule / image) used to be undeletable — StarterKit's Backspace
+ * (joinBackward) is a no-op there because nothing precedes it to merge into.
+ * `deleteEmptyLeadingBlock` removes that empty leading block when another block
+ * follows. Verified at the ProseMirror state level (no DOM needed).
+ */
+import { describe, it, expect } from 'vitest';
+import { getSchema } from '@tiptap/core';
+import { EditorState, TextSelection } from '@tiptap/pm/state';
+import { chainCommands, deleteSelection, joinBackward, selectNodeBackward } from '@tiptap/pm/commands';
+import { createBaseExtensions, deleteEmptyLeadingBlock } from '@/components/editor/plugins/extensions';
+
+const schema = getSchema(createBaseExtensions());
+
+// StarterKit's default Backspace deletion chain (without our handler).
+const defaultBackspace = chainCommands(deleteSelection, joinBackward, selectNodeBackward);
+
+function run(
+  cmd: (s: EditorState, d?: (tr: import('@tiptap/pm/state').Transaction) => void) => boolean,
+  doc: ReturnType<typeof schema.node>,
+  pos: number,
+) {
+  const state = EditorState.create({ schema, doc, selection: TextSelection.create(doc, pos) });
+  let next = state;
+  const handled = cmd(state, (tr) => { next = state.apply(tr); });
+  return { handled, doc: next.doc };
+}
+
+const bulletList = () =>
+  schema.node('bulletList', null, [
+    schema.node('listItem', null, [schema.node('paragraph', null, [schema.text('item')])]),
+  ]);
+
+describe('deleteEmptyLeadingBlock (Backspace fix)', () => {
+  it('default Backspace cannot remove an empty leading paragraph above a list', () => {
+    const doc = schema.node('doc', null, [schema.node('paragraph'), bulletList()]);
+    const r = run(defaultBackspace, doc, 1);
+    expect(r.handled).toBe(false); // the bug
+    expect(r.doc.eq(doc)).toBe(true);
+  });
+
+  it('removes the empty leading paragraph above a bullet list', () => {
+    const doc = schema.node('doc', null, [schema.node('paragraph'), bulletList()]);
+    const r = run(deleteEmptyLeadingBlock, doc, 1);
+    expect(r.handled).toBe(true);
+    expect(r.doc.childCount).toBe(1);
+    expect(r.doc.firstChild?.type.name).toBe('bulletList');
+  });
+
+  it('removes the empty leading paragraph above a horizontal rule', () => {
+    const doc = schema.node('doc', null, [schema.node('paragraph'), schema.node('horizontalRule')]);
+    const r = run(deleteEmptyLeadingBlock, doc, 1);
+    expect(r.handled).toBe(true);
+    expect(r.doc.childCount).toBe(1);
+    expect(r.doc.firstChild?.type.name).toBe('horizontalRule');
+  });
+
+  it('does NOT touch a non-empty leading paragraph', () => {
+    const doc = schema.node('doc', null, [schema.node('paragraph', null, [schema.text('hi')]), bulletList()]);
+    const r = run(deleteEmptyLeadingBlock, doc, 1);
+    expect(r.handled).toBe(false);
+    expect(r.doc.eq(doc)).toBe(true);
+  });
+
+  it('does NOT delete the only block (empty doc must keep one paragraph)', () => {
+    const doc = schema.node('doc', null, [schema.node('paragraph')]);
+    const r = run(deleteEmptyLeadingBlock, doc, 1);
+    expect(r.handled).toBe(false);
+  });
+
+  it('defers to default Backspace for an empty paragraph that is NOT first (joinBackward works)', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('hi')]),
+      schema.node('paragraph'),
+      bulletList(),
+    ]);
+    // our handler declines (not the first block) ...
+    expect(run(deleteEmptyLeadingBlock, doc, 5).handled).toBe(false);
+    // ... and the default chain handles it by merging the empty para into "hi".
+    expect(run(defaultBackspace, doc, 5).handled).toBe(true);
+  });
+});

--- a/src/components/editor/plugins/extensions.ts
+++ b/src/components/editor/plugins/extensions.ts
@@ -6,6 +6,7 @@
  */
 
 import { Extension, type RawCommands, type CommandProps } from '@tiptap/core';
+import type { EditorState, Transaction } from '@tiptap/pm/state';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import Link from '@tiptap/extension-link';
@@ -108,6 +109,34 @@ const IndentExtension = Extension.create({
                 if (current <= 0) return false;
                 return this.editor.chain().updateAttributes(nodeType, { indent: current - 1 }).run();
             },
+        };
+    },
+});
+
+/**
+ * Deletes an empty top-level textblock at the very START of the document when
+ * another block follows it. StarterKit's Backspace (joinBackward) is a no-op
+ * there — nothing precedes the block to merge into — so a stray blank line above
+ * a list, horizontal rule, or image otherwise can't be removed. Pure command so
+ * it's unit-testable at the ProseMirror state level.
+ */
+export function deleteEmptyLeadingBlock(state: EditorState, dispatch?: (tr: Transaction) => void): boolean {
+    const { $from, empty } = state.selection;
+    if (!empty) return false;
+    if ($from.depth !== 1 || !$from.parent.isTextblock) return false; // top-level textblock only
+    if ($from.parent.content.size > 0) return false;                  // must be empty
+    if ($from.before() !== 0) return false;                           // must be the first block
+    if (state.doc.childCount < 2) return false;                       // keep the last block
+    if (dispatch) dispatch(state.tr.delete(0, $from.after()));
+    return true;
+}
+
+const DeleteEmptyLeadingBlock = Extension.create({
+    name: 'deleteEmptyLeadingBlock',
+    addKeyboardShortcuts() {
+        return {
+            Backspace: () =>
+                this.editor.commands.command(({ state, dispatch }) => deleteEmptyLeadingBlock(state, dispatch)),
         };
     },
 });
@@ -227,6 +256,7 @@ export function createBaseExtensions(options?: ExtensionOptions) {
         ClearFormattingShortcut,
         DuplicateBlock,
         IndentExtension,
+        DeleteEmptyLeadingBlock,
         SearchAndReplace,
     ];
 }


### PR DESCRIPTION
## Problem

An empty paragraph at the **very top** of the document — above a bullet list, horizontal rule, or image — could not be removed. StarterKit's Backspace runs `joinBackward`, which is a no-op when there is nothing before the block to merge into, so the stray blank line stayed stuck (cursor inside it, Backspace did nothing). Reported on the "Shared Lists" note.

Reproduced at the ProseMirror state level: the empty *leading* block is stuck, while an empty paragraph anywhere else deletes fine via `joinBackward`.

## Fix

A pure, testable command `deleteEmptyLeadingBlock` bound to Backspace (`src/components/editor/plugins/extensions.ts`): when the cursor is in an **empty top-level textblock that is the document's first child** and **another block follows**, it removes that block. Otherwise it returns `false`, so all normal Backspace behavior is preserved.

Deliberately narrow — guards prevent it from firing on:
- a non-empty leading paragraph,
- a cursor inside a list/table (depth check),
- the document's only block (the doc always keeps one paragraph).

## Tests

`src/__tests__/editorBackspace.test.ts` (6 state-level cases, no DOM):
- the bug itself (default Backspace no-op),
- removal of the empty leading paragraph above a list and above a horizontal rule,
- guards: non-empty block, only-block, and a non-first empty paragraph correctly deferring to the default chain.

`npm run build` / `npm run test` (282 pass) / `npm run lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)