### PR TITLE
fix(editor): keep editor stable so Yjs undo/redo history survives

### DIFF
--- a/src/__tests__/undoRedo.test.ts
+++ b/src/__tests__/undoRedo.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+/**
+ * Undo/redo is provided by y-prosemirror's UndoManager (StarterKit history is
+ * disabled because Yjs owns history). These tests pin two invariants:
+ *   1. undo/redo actually revert/replay a local edit with the real extensions;
+ *   2. recreating the editor on the same Yjs fragment WIPES undo history — which
+ *      is why EditorProvider must keep a single stable editor per note instead of
+ *      recreating it when AI-readiness / settings change.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import * as Y from 'yjs';
+import { createBaseExtensions } from '@/components/editor/plugins/extensions';
+import { createCollaborationExtension, undo, redo } from '@/components/editor/plugins/collaboration';
+
+function makeEditor(fragment: Y.XmlFragment) {
+  const element = document.createElement('div');
+  return new Editor({ element, extensions: [...createBaseExtensions(), createCollaborationExtension(fragment)] });
+}
+
+describe('y-prosemirror undo/redo', () => {
+  let ydoc: Y.Doc;
+  let fragment: Y.XmlFragment;
+  let editor: Editor;
+
+  beforeEach(() => {
+    ydoc = new Y.Doc();
+    fragment = ydoc.getXmlFragment('prosemirror');
+    editor = makeEditor(fragment);
+  });
+
+  it('undo reverts and redo replays a local text insertion', async () => {
+    editor.commands.insertContent('hello world');
+    // The UndoManager batches edits within ~500ms; pause so the insert is its
+    // own undo step (mirrors a real pause between edits).
+    await new Promise((r) => setTimeout(r, 600));
+
+    expect(undo(editor.state)).toBe(true);
+    expect(editor.getText()).toBe('');
+    expect(redo(editor.state)).toBe(true);
+    expect(editor.getText()).toBe('hello world');
+  });
+
+  it('undo works immediately after typing (no capture pause)', () => {
+    editor.commands.insertContent('abc');
+    expect(undo(editor.state)).toBe(true);
+    expect(editor.getText()).toBe('');
+  });
+
+  it('recreating the editor on the same fragment loses undo history', () => {
+    editor.commands.insertContent('typed before recreation');
+    editor.destroy();
+
+    // A second editor bound to the SAME fragment: content survives (it lives in
+    // Yjs) but the UndoManager is brand new, so the prior edit can't be undone.
+    const editor2 = makeEditor(fragment);
+    expect(editor2.getText()).toBe('typed before recreation');
+    expect(undo(editor2.state)).toBe(false);
+    expect(editor2.getText()).toBe('typed before recreation');
+    editor2.destroy();
+  });
+});

--- a/src/components/editor/EditorProvider.tsx
+++ b/src/components/editor/EditorProvider.tsx
@@ -74,6 +74,18 @@ export function EditorProvider({
     isGrammarEnabledRef.current = aiSettings.grammarEnabled;
   }, [aiSettings.grammarEnabled]);
 
+  // Route the AI callbacks through refs too. Their identities change whenever
+  // isAIReady flips (WebLLM finishes loading) or autocomplete is toggled; if they
+  // were extension-memo deps the editor would be recreated, which discards the
+  // y-prosemirror UndoManager and silently breaks undo/redo. Reading the latest
+  // callback at call time keeps the editor — and its undo history — stable.
+  const onGetAutocompleteSuggestionRef = useRef(onGetAutocompleteSuggestion);
+  const onCheckGrammarRef = useRef(onCheckGrammar);
+  useEffect(() => {
+    onGetAutocompleteSuggestionRef.current = onGetAutocompleteSuggestion;
+    onCheckGrammarRef.current = onCheckGrammar;
+  }, [onGetAutocompleteSuggestion, onCheckGrammar]);
+
   // Get Yjs fragment for ProseMirror - memoized to avoid recreating on every render
   const yXmlFragment = useMemo(
     () => yDoc.getXmlFragment("prosemirror"),
@@ -150,6 +162,12 @@ export function EditorProvider({
     },
     [docId, sync],
   );
+  // Ref so the file handler can reach the latest callback without the editor
+  // being recreated when its identity changes (see undo/redo note above).
+  const handleImageDropRef = useRef(handleImageDrop);
+  useEffect(() => {
+    handleImageDropRef.current = handleImageDrop;
+  }, [handleImageDrop]);
 
   // Handle document updates from broadcast (sync service)
   const handleDocumentUpdate = useCallback(async () => {
@@ -174,16 +192,19 @@ export function EditorProvider({
         // Custom shortcuts can trigger actions here if needed
       }),
       // File handler for image drag/drop/paste
+      // eslint-disable-next-line react-hooks/refs -- ref read happens on drop, not during render
       FileHandler.configure({
         maxSizeMB: 5,
         allowedTypes: ["image/jpeg", "image/png", "image/gif", "image/webp"],
-        onImageDrop: handleImageDrop,
+        onImageDrop: (file: File, pendingId: string) => handleImageDropRef.current(file, pendingId),
       }),
-      // AI-powered plugins (conditionally active)
-      // eslint-disable-next-line react-hooks/refs -- getIsAIReady is a getter called only within plugin execution, not during render
+      // AI-powered plugins (conditionally active). All inputs are read via refs
+      // at call time so the editor (and its undo history) is never recreated when
+      // AI readiness / settings change.
+      // eslint-disable-next-line react-hooks/refs -- getters are called only within plugin execution, not during render
       AutocompletePlugin.configure({
-        getSuggestion: onGetAutocompleteSuggestion || (async () => ""),
-        getIsAIReady: () => isAIReadyRef.current, // Use getter function to defer ref read
+        getSuggestion: (text: string) => onGetAutocompleteSuggestionRef.current?.(text) ?? Promise.resolve(""),
+        getIsAIReady: () => isAIReadyRef.current,
         debounceMs: 500,
         minCharsBeforeTrigger: 5,
         debug: false,
@@ -191,9 +212,9 @@ export function EditorProvider({
       // Slash commands (triggered by typing /)
       SlashCommandsExtension,
       // Grammar plugin — always included, checks getIsGrammarEnabled() at runtime
-      // eslint-disable-next-line react-hooks/refs -- getIsAIReady/getIsGrammarEnabled are getters called only within plugin execution, not during render
+      // eslint-disable-next-line react-hooks/refs -- getters are called only within plugin execution, not during render
       GrammarPlugin.configure({
-        checkGrammar: onCheckGrammar || (async () => []),
+        checkGrammar: (text: string) => onCheckGrammarRef.current?.(text) ?? Promise.resolve([]),
         getIsAIReady: () => isAIReadyRef.current,
         getIsGrammarEnabled: () => isGrammarEnabledRef.current,
         debounceMs: 3000,
@@ -201,12 +222,9 @@ export function EditorProvider({
         debug: false,
       }),
     ],
-    [
-      yXmlFragment,
-      onGetAutocompleteSuggestion,
-      onCheckGrammar,
-      handleImageDrop,
-    ],
+    // Only the Yjs fragment is a real input; everything else is read via refs so
+    // the editor is created once per note and undo/redo history survives.
+    [yXmlFragment],
   );
 
   // Create TipTap editor with performance optimizations


### PR DESCRIPTION
## Problem

Undo/redo silently stops working — typically right after the AI model finishes loading in the background, or when autocomplete is toggled in settings.

## Root cause

Undo/redo is owned by **y-prosemirror's `UndoManager`** (StarterKit's native history is disabled because Yjs owns history). `EditorProvider` builds the editor with `useEditor(opts, [extensions])`, and the `extensions` `useMemo` depended on the AI callback props (`onGetAutocompleteSuggestion`, `onCheckGrammar`) and `handleImageDrop`.

Those callback identities change when **`isAIReady` flips** (WebLLM finishes loading) or autocomplete is toggled — which recreates the entire editor. A recreated editor gets a **brand-new `UndoManager`**, discarding all undo/redo history. The content survives (it lives in Yjs), but the prior edits can no longer be undone.

Verified at two levels:
- y-prosemirror undo/redo works correctly in isolation with the real extension stack;
- recreating the editor on the same Yjs fragment preserves content but `undo()` returns `false` — the exact failure mode.

## Fix

Route the three callbacks through refs (matching the existing `isAIReadyRef` / `isGrammarEnabledRef` pattern) and read them at call time. The `extensions` memo now depends only on `yXmlFragment`, so the editor is created **once per note** and its undo history persists across AI-readiness and settings changes.

## Tests

`src/__tests__/undoRedo.test.ts` (headless, happy-dom):
- undo reverts and redo replays a local edit with the real extensions,
- undo works immediately after typing (no capture pause),
- a guard documenting that recreating the editor on the same fragment wipes history (the failure mode this fixes).

`npm run build` / `npm run test` (285 pass) / `npm run lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)