### PR TITLE
fix(editor): split hard-breaks into paragraphs on paste

### DIFF
--- a/src/__tests__/editorPaste.test.ts
+++ b/src/__tests__/editorPaste.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+/**
+ * Regression: multi-line content pasted from the web (YouTube comments, Notion,
+ * chat apps) arrives as ONE block whose lines are joined by <br> hard-breaks.
+ * Block formatting (Heading/List) then hit the whole block — selecting one line
+ * and pressing "Heading 2" converted every line, and toggling a list collapsed
+ * everything into a single un-exitable item. `splitHardBreaksSlice` (wired as a
+ * transformPasted plugin) splits those hard-breaks into real paragraphs on paste.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import type { EditorView } from '@tiptap/pm/view';
+import type { Slice } from '@tiptap/pm/model';
+import * as pmView from '@tiptap/pm/view';
+import { splitHardBreaksSlice } from '@/components/editor/plugins/extensions';
+
+// __parseFromClipboard is exported at runtime but absent from the type defs.
+const parseFromClipboard = (pmView as unknown as {
+  __parseFromClipboard: (view: EditorView, text: string, html: string | null, plainText: boolean, $ctx: unknown) => Slice | null;
+}).__parseFromClipboard;
+
+function mkEditor() {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  return new Editor({
+    element: el,
+    extensions: [StarterKit.configure({ codeBlock: false, undoRedo: false, link: false, underline: false })],
+    content: '<p></p>',
+  });
+}
+
+// Simulate a real paste: parse the clipboard exactly like ProseMirror, run our
+// transform (what the transformPasted plugin does), then insert.
+function paste(editor: Editor, html: string, text = '') {
+  const view = editor.view;
+  const raw = parseFromClipboard(view, text, html, false, view.state.selection.$from);
+  if (!raw) return;
+  const transformed = splitHardBreaksSlice(raw, view.state.schema);
+  view.dispatch(view.state.tr.replaceSelection(transformed));
+}
+
+describe('splitHardBreaksSlice — paste of <br>-joined content', () => {
+  let e: Editor;
+  beforeEach(() => { e = mkEditor(); });
+
+  it('splits bare <br> lines into separate paragraphs', () => {
+    paste(e, 'Line A<br>Line B<br>Line C');
+    expect(e.getHTML()).toBe('<p>Line A</p><p>Line B</p><p>Line C</p>');
+  });
+
+  it('lets Heading 2 apply to ONE line only (bug: used to convert every line)', () => {
+    paste(e, 'Line A<br>Line B<br>Line C');
+    e.chain().setTextSelection({ from: 1, to: 7 }).toggleHeading({ level: 2 }).run();
+    expect(e.getHTML()).toBe('<h2>Line A</h2><p>Line B</p><p>Line C</p>');
+  });
+
+  it('lets a bullet list become separate, exitable items (bug: was one item)', () => {
+    paste(e, '<div>One<br>Two<br>Three</div>');
+    e.chain().selectAll().toggleBulletList().run();
+    expect(e.getHTML()).toBe(
+      '<ul><li><p>One</p></li><li><p>Two</p></li><li><p>Three</p></li></ul><p></p>',
+    );
+  });
+
+  it('handles the real YouTube recipe comment (blank lines preserved)', () => {
+    paste(e, '🍰 Ingredients:<br><br>Plain Flour 200g<br>Sugar 150g<br>Eggs 3');
+    const types = e.getJSON().content?.map((n) => n.type);
+    expect(types).toEqual(['paragraph', 'paragraph', 'paragraph', 'paragraph', 'paragraph']);
+    expect(e.getHTML()).toBe(
+      '<p>🍰 Ingredients:</p><p></p><p>Plain Flour 200g</p><p>Sugar 150g</p><p>Eggs 3</p>',
+    );
+  });
+
+  it('merges first/last line into the surrounding paragraph when pasted mid-line', () => {
+    e.commands.setContent('<p>HelloWorld</p>');
+    e.chain().setTextSelection(6).run(); // between "Hello" and "World"
+    paste(e, 'AAA<br>BBB');
+    expect(e.getHTML()).toBe('<p>HelloAAA</p><p>BBBWorld</p>');
+  });
+
+  it('leaves single-line paste (no hard-break) untouched', () => {
+    paste(e, 'just one line', 'just one line');
+    expect(e.getHTML()).toBe('<p>just one line</p>');
+  });
+
+  it('leaves plain-text paste (already separate paragraphs) untouched', () => {
+    paste(e, '', 'First.\n\nSecond.\n\nThird.');
+    expect(e.getHTML()).toBe('<p>First.</p><p>Second.</p><p>Third.</p>');
+  });
+});
+
+describe('SplitHardBreaksOnPaste — wired into the real editor extensions', () => {
+  it('registers a transformPasted prop via createBaseExtensions', async () => {
+    const { createBaseExtensions } = await import('@/components/editor/plugins/extensions');
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const editor = new Editor({ element: el, extensions: createBaseExtensions(), content: '<p></p>' });
+    expect(editor.view.someProp('transformPasted')).toBeTypeOf('function');
+    editor.destroy();
+  });
+});

--- a/src/components/editor/plugins/extensions.ts
+++ b/src/components/editor/plugins/extensions.ts
@@ -6,7 +6,8 @@
  */
 
 import { Extension, type RawCommands, type CommandProps } from '@tiptap/core';
-import type { EditorState, Transaction } from '@tiptap/pm/state';
+import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
+import { Fragment, Slice, type Node as PMNode, type Schema } from '@tiptap/pm/model';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import Link from '@tiptap/extension-link';
@@ -187,6 +188,74 @@ const CustomImage = Image.extend({
 });
 
 
+function fragmentHasHardBreak(frag: Fragment): boolean {
+    let found = false;
+    frag.forEach(child => { if (child.type.name === 'hardBreak') found = true; });
+    return found;
+}
+
+// Split an inline fragment into nodes of `type`, breaking at each hardBreak.
+function splitAtHardBreaks(frag: Fragment, type: PMNode['type'], attrs?: PMNode['attrs'], marks?: PMNode['marks']): PMNode[] {
+    const out: PMNode[] = [];
+    let buffer: PMNode[] = [];
+    const flush = () => { out.push(type.create(attrs, buffer.length ? Fragment.fromArray(buffer) : null, marks)); buffer = []; };
+    frag.forEach(child => { if (child.type.name === 'hardBreak') flush(); else buffer.push(child); });
+    flush();
+    return out;
+}
+
+function splitBlockFragment(frag: Fragment): Fragment {
+    const out: PMNode[] = [];
+    frag.forEach(node => {
+        if (node.isTextblock && fragmentHasHardBreak(node.content)) {
+            out.push(...splitAtHardBreaks(node.content, node.type, node.attrs, node.marks));
+        } else if (!node.isText && node.content.size > 0) {
+            out.push(node.copy(splitBlockFragment(node.content)));
+        } else {
+            out.push(node);
+        }
+    });
+    return Fragment.fromArray(out);
+}
+
+/**
+ * Multi-line content pasted from the web (YouTube comments, Notion, chat apps, …)
+ * arrives as a single block whose lines are joined by <br> hard-breaks. Block-level
+ * formatting (headings, lists) then applies to the WHOLE block — selecting one line
+ * and pressing "Heading 2" converts every line, and toggling a list collapses
+ * everything into one un-exitable list item. Splitting those hard-breaks into real
+ * paragraphs on paste makes each line independently formattable. Only runs on paste,
+ * so soft breaks typed with Shift+Enter inside the editor are left untouched, and
+ * code-block pastes (plain text, no hardBreak nodes) pass through unchanged.
+ */
+export function splitHardBreaksSlice(slice: Slice, schema: Schema): Slice {
+    const first = slice.content.firstChild;
+    if (!first) return slice;
+    if (first.isInline) {
+        if (!fragmentHasHardBreak(slice.content)) return slice;
+        const paragraphs = splitAtHardBreaks(slice.content, schema.nodes.paragraph);
+        // openStart/End = 1 so the first/last lines merge into the surrounding
+        // block when pasting into the middle of an existing paragraph.
+        return new Slice(Fragment.fromArray(paragraphs), 1, 1);
+    }
+    return new Slice(splitBlockFragment(slice.content), slice.openStart, slice.openEnd);
+}
+
+const SplitHardBreaksOnPaste = Extension.create({
+    name: 'splitHardBreaksOnPaste',
+    addProseMirrorPlugins() {
+        const editor = this.editor;
+        return [
+            new Plugin({
+                key: new PluginKey('splitHardBreaksOnPaste'),
+                props: {
+                    transformPasted: slice => splitHardBreaksSlice(slice, editor.schema),
+                },
+            }),
+        ];
+    },
+});
+
 /**
  * Type for extension configuration options
  */
@@ -257,6 +326,7 @@ export function createBaseExtensions(options?: ExtensionOptions) {
         DuplicateBlock,
         IndentExtension,
         DeleteEmptyLeadingBlock,
+        SplitHardBreaksOnPaste,
         SearchAndReplace,
     ];
 }


### PR DESCRIPTION
## Bugs 1 & 2 — formatting/list hits every line after paste

**Symptom**
- Select one line of pasted text + Heading 2 → *every* line became a heading.
- Toggle a bullet list on pasted text → everything collapsed into one un-exitable item.

**Root cause**
Web content (YouTube comments, Notion, chat apps) is pasted as a **single block** whose lines are joined by `<br>` hard-breaks rather than real paragraph nodes. Block-level formatting (Heading, List) applies to the whole containing block, so it hit every line at once.

**Fix**
A `transformPasted` ProseMirror plugin (`splitHardBreaksSlice`) splits hard-breaks into real paragraphs **on paste only**. Typed `Shift+Enter` soft-breaks are unaffected. Handles both bare-`<br>` (inline-root, `openStart=0`) and wrapped (block-root) clipboard slices.

**Tests**
`src/__tests__/editorPaste.test.ts` — 8 regression tests against a real TipTap editor, including the exact YouTube recipe content that triggered the report. All pass.

**Verify**
Paste the recipe comment → each line its own paragraph; select one line + Heading 2 → only that line; bullet-list a few lines → separate, exitable items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEMHL2RQH7eVNcKmWmrd6f