### PR TITLE
fix(notes): keep public notes unencrypted/Anonymous when edited

### DIFF
--- a/src/__tests__/updateNotePublic.test.ts
+++ b/src/__tests__/updateNotePublic.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression: editing a PUBLIC note used to fail. updateNote hardcoded
+ * isEncrypted:true + Owner ACL and passed a cached key header, so saving a public
+ * (Anonymous, unencrypted) note tried to encrypt it with a key the file doesn't
+ * have — the SDK rejected the patch (or silently reverted the share). The save
+ * path must mirror makeNotePublic: Anonymous ACL, isEncrypted:false, no key header.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { DotYouClient } from '@homebase-id/js-lib/core';
+import { SecurityGroupType } from '@homebase-id/js-lib/core';
+import type { EncryptedKeyHeader } from '@homebase-id/js-lib/core';
+import type { DocumentMetadata } from '@/types';
+
+const { mockPatch } = vi.hoisted(() => ({ mockPatch: vi.fn() }));
+vi.mock('@homebase-id/js-lib/core', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@homebase-id/js-lib/core')>();
+    return { ...actual, patchFile: mockPatch };
+});
+
+import { NotesDriveProvider } from '@/lib/homebase/NotesDriveProvider';
+
+const NOTE_ID = '11111111-1111-1111-1111-111111111111';
+const fakeClient = { getHostIdentity: () => 'me.dotyou.cloud' } as unknown as DotYouClient;
+const fakeKeyHeader = { encryptionVersion: 1 } as unknown as EncryptedKeyHeader;
+
+function meta(over: Partial<DocumentMetadata>): DocumentMetadata {
+    return { title: 'Note', tags: [], ...over } as DocumentMetadata;
+}
+
+// patchFile args: (client, keyHeader, instructions, uploadMetadata, payloads, ...)
+const keyHeaderArg = () => mockPatch.mock.calls[0][1];
+const uploadMeta = () => mockPatch.mock.calls[0][3];
+
+describe('NotesDriveProvider.updateNote — encryption/ACL by visibility', () => {
+    let provider: NotesDriveProvider;
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockPatch.mockResolvedValue({ newVersionTag: 'v2' });
+        provider = new NotesDriveProvider(fakeClient);
+    });
+
+    it('saves a PUBLIC note unencrypted, Anonymous, with no key header', async () => {
+        await provider.updateNote(NOTE_ID, 'file-1', 'v1', meta({ isPublic: true }),
+            undefined, undefined, undefined, fakeKeyHeader);
+
+        expect(uploadMeta().isEncrypted).toBe(false);
+        expect(uploadMeta().accessControlList.requiredSecurityGroup).toBe(SecurityGroupType.Anonymous);
+        expect(keyHeaderArg()).toBeUndefined();
+    });
+
+    it('saves a PRIVATE note encrypted, Owner, keeping the key header', async () => {
+        await provider.updateNote(NOTE_ID, 'file-1', 'v1', meta({ isPublic: false }),
+            undefined, undefined, undefined, fakeKeyHeader);
+
+        expect(uploadMeta().isEncrypted).toBe(true);
+        expect(uploadMeta().accessControlList.requiredSecurityGroup).toBe(SecurityGroupType.Owner);
+        expect(keyHeaderArg()).toBe(fakeKeyHeader);
+    });
+
+    it('saves a COLLABORATIVE note encrypted with Connected ACL', async () => {
+        await provider.updateNote(NOTE_ID, 'file-1', 'v1',
+            meta({ isCollaborative: true, circleIds: ['circle-1'] }),
+            undefined, undefined, undefined, fakeKeyHeader);
+
+        expect(uploadMeta().isEncrypted).toBe(true);
+        expect(uploadMeta().accessControlList.requiredSecurityGroup).toBe(SecurityGroupType.Connected);
+    });
+});

--- a/src/lib/homebase/NotesDriveProvider.ts
+++ b/src/lib/homebase/NotesDriveProvider.ts
@@ -381,7 +381,14 @@ export class NotesDriveProvider {
             });
         }
 
-        const accessControlList = metadata.isCollaborative && metadata.circleIds?.length
+        // A public note is stored Anonymous + unencrypted (see makeNotePublic).
+        // Editing one must NOT re-encrypt it or revert the ACL to Owner, or the
+        // share breaks and the SDK tries to encrypt with a key the file lacks.
+        const accessControlList = metadata.isPublic
+            ? {
+                requiredSecurityGroup: SecurityGroupType.Anonymous,
+            }
+            : metadata.isCollaborative && metadata.circleIds?.length
             ? {
                 requiredSecurityGroup: SecurityGroupType.Connected,
                 circleIdList: metadata.circleIds,
@@ -403,7 +410,7 @@ export class NotesDriveProvider {
                 content: JSON.stringify(noteContent),
                 archivalStatus: metadata.archivalStatus ?? 0,
             },
-            isEncrypted: true,
+            isEncrypted: !metadata.isPublic,
             accessControlList,
         };
 
@@ -426,7 +433,9 @@ export class NotesDriveProvider {
 
         const result = await patchFile(
             this.#dotYouClient,
-            cachedKeyHeader,
+            // No key header for a public note — it's stored unencrypted, so passing
+            // a cached (or empty) header would make the SDK encrypt the payload.
+            metadata.isPublic ? undefined : cachedKeyHeader,
             updateInstructions,
             uploadMetadata,
             payloads,


### PR DESCRIPTION
## Bug 3 — public note can't be edited (re-encrypts)

**Symptom**
Editing a note after making it public failed / silently reverted — the file "tried to encrypt" a note that's stored unencrypted.

**Root cause**
`updateNote` hardcoded `isEncrypted: true` + Owner ACL and passed the cached `EncryptedKeyHeader`. A public note is stored **Anonymous + unencrypted**, so re-saving it tried to encrypt with a key the file doesn't have — the SDK rejected the patch (or reverted the share to Owner).

**Fix**
`updateNote` now derives encryption/ACL from visibility, mirroring `makeNotePublic`:
- `isPublic` → Anonymous ACL, `isEncrypted: false`, **no** key header (`undefined`)
- collaborative → Connected ACL (+ circle list), encrypted
- otherwise → Owner ACL, encrypted

**Tests**
`src/__tests__/updateNotePublic.test.ts` — asserts the correct ACL / `isEncrypted` / key-header arg for all three visibility paths. All pass.

**Verify** ⚠️ *needs live Homebase backend*
Make a note public → edit it → confirm it saves **and** the public share link still resolves (stays Anonymous/unencrypted). The offline test proves the SDK call args; the actual unencrypted-patch round-trip against your server is the one thing I couldn't test offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEMHL2RQH7eVNcKmWmrd6f