### PR TITLE
fix(editor): reliable autosave — first edit + trailing edits on unmount

### DIFF
--- a/src/__tests__/flushPendingSave.test.ts
+++ b/src/__tests__/flushPendingSave.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression: the last keystrokes before a note switch/unmount were lost from
+ * the server. Content reaches Homebase only via the editor's debounced save,
+ * and unmount cancelled the pending timer — so the final edits stayed in PGlite
+ * but never got pushed. flushPendingSaveOnTeardown fires that pending save on
+ * teardown, but only AFTER destroy()'s compaction so the upload can't read the
+ * empty mid-compaction window and clobber the note.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { flushPendingSaveOnTeardown } from '@/lib/yjs/flushPendingSave';
+
+function fakeProvider() {
+    let resolveDestroy!: () => void;
+    const destroyed = new Promise<void>((r) => {
+        resolveDestroy = r;
+    });
+    return {
+        getFullState: vi.fn(() => new Uint8Array([1, 2, 3])),
+        destroy: vi.fn(() => destroyed),
+        finishDestroy: () => resolveDestroy(),
+    };
+}
+
+describe('flushPendingSaveOnTeardown', () => {
+    it('pushes the captured state, but only after destroy() resolves', async () => {
+        const p = fakeProvider();
+        const onSave = vi.fn();
+
+        flushPendingSaveOnTeardown(p, true, onSave);
+
+        // State captured synchronously (doc still alive); push deferred.
+        expect(p.getFullState).toHaveBeenCalledTimes(1);
+        expect(p.destroy).toHaveBeenCalledTimes(1);
+        expect(onSave).not.toHaveBeenCalled();
+
+        p.finishDestroy();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(onSave).toHaveBeenCalledTimes(1);
+        expect(onSave).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+    });
+
+    it('tears down without saving when nothing is pending', async () => {
+        const p = fakeProvider();
+        const onSave = vi.fn();
+
+        flushPendingSaveOnTeardown(p, false, onSave);
+
+        expect(p.destroy).toHaveBeenCalledTimes(1);
+        expect(p.getFullState).not.toHaveBeenCalled();
+
+        p.finishDestroy();
+        await Promise.resolve();
+        expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('still tears down when there is no onSave handler', () => {
+        const p = fakeProvider();
+        expect(() => flushPendingSaveOnTeardown(p, true, undefined)).not.toThrow();
+        expect(p.destroy).toHaveBeenCalledTimes(1);
+        expect(p.getFullState).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/editor/EditorProvider.tsx
+++ b/src/components/editor/EditorProvider.tsx
@@ -9,6 +9,7 @@ import {
 import { useAISettings } from "@/hooks/useAISettings";
 import { useEditor, type Editor } from "@tiptap/react";
 import * as Y from "yjs";
+import { ySyncPluginKey } from "y-prosemirror";
 import { PGliteProvider } from "@/lib/yjs";
 import { upsertSearchIndex, savePendingImageUpload } from "@/lib/db";
 import type { DocumentMetadata } from "@/types";
@@ -338,7 +339,6 @@ export function EditorProvider({
   useEffect(() => {
     if (!editor || !providerRef.current || isLoading) return;
 
-    let skipInitial = true;
     const handleUpdate = ({
       transaction,
     }: {
@@ -348,9 +348,13 @@ export function EditorProvider({
         return;
       }
 
-      // Skip the first docChanged after attaching — that's the Yjs initial content load
-      if (skipInitial) {
-        skipInitial = false;
+      // Skip Yjs-originated transactions (initial content load + remote sync);
+      // only genuine local user edits should trigger a save. y-prosemirror tags
+      // its own doc→editor sync transactions with isChangeOrigin. The previous
+      // one-shot "skip the first docChanged" dropped the user's FIRST edit — e.g.
+      // pasting into a fresh note never saved — because the initial-load update
+      // fires before this listener attaches (or not at all for an empty note).
+      if (transaction.getMeta(ySyncPluginKey)?.isChangeOrigin) {
         return;
       }
 

--- a/src/components/editor/EditorProvider.tsx
+++ b/src/components/editor/EditorProvider.tsx
@@ -11,6 +11,7 @@ import { useEditor, type Editor } from "@tiptap/react";
 import * as Y from "yjs";
 import { ySyncPluginKey } from "y-prosemirror";
 import { PGliteProvider } from "@/lib/yjs";
+import { flushPendingSaveOnTeardown } from "@/lib/yjs/flushPendingSave";
 import { upsertSearchIndex, savePendingImageUpload } from "@/lib/db";
 import type { DocumentMetadata } from "@/types";
 import { EditorContext } from "./EditorContext";
@@ -61,6 +62,10 @@ export function EditorProvider({
   // Use refs for cleanup to avoid stale closure issues
   const providerRef = useRef<PGliteProvider | null>(null);
   const editorRef = useRef<Editor | null>(null);
+  // Declared here (not next to debouncedSave) so the provider-init cleanup below
+  // can flush a still-pending save on unmount.
+  const onSaveRef = useRef(onSave);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Store AI ready state in ref for plugin access
   const isAIReadyRef = useRef(isAIReady);
@@ -118,8 +123,18 @@ export function EditorProvider({
 
     return () => {
       mounted = false;
-      providerRef.current?.destroy();
+      const provider = providerRef.current;
       providerRef.current = null;
+      if (!provider) return;
+      // A note switch unmounts this (it's keyed by noteId). If a debounced save
+      // is still pending, flush it so the last edits — already in PGlite — also
+      // reach the server instead of being dropped with the timer.
+      const hasPendingSave = saveTimeoutRef.current !== null;
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+      }
+      flushPendingSaveOnTeardown(provider, hasPendingSave, onSaveRef.current);
     };
   }, [docId, yDoc]);
 
@@ -263,7 +278,6 @@ export function EditorProvider({
   // Refs for current values - avoids stale closures in debounced functions
   const docIdRef = useRef(docId);
   const metadataRef = useRef(metadata);
-  const onSaveRef = useRef(onSave);
 
   // Keep refs in sync with props
   useEffect(() => {
@@ -276,7 +290,6 @@ export function EditorProvider({
   const searchIndexTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const updateSearchIndex = useCallback(
     (editorInstance: Editor, plainTextContent?: string) => {

--- a/src/lib/yjs/flushPendingSave.ts
+++ b/src/lib/yjs/flushPendingSave.ts
@@ -1,0 +1,33 @@
+/**
+ * Teardown-time flush for the editor's debounced server save.
+ *
+ * Content edits reach the server only through EditorProvider's 2s-debounced
+ * save (they are never marked sync_status='pending', so the periodic sync
+ * skips them). When the editor unmounts — and note switches unmount it, since
+ * it's keyed by noteId — a still-pending save would be cancelled, so the last
+ * keystrokes live in PGlite but never get pushed.
+ *
+ * This flushes that pending save on teardown. The push must happen only AFTER
+ * destroy() finishes: destroy() compacts the local updates (delete-then-rewrite
+ * in PGlite), and the server push re-reads PGlite — reading mid-compaction can
+ * catch the empty window and clobber the note on the server.
+ */
+type TeardownProvider = {
+    getFullState(): Uint8Array;
+    destroy(): Promise<void>;
+};
+
+export function flushPendingSaveOnTeardown(
+    provider: TeardownProvider,
+    hasPendingSave: boolean,
+    onSave: ((blob: Uint8Array) => void) | undefined,
+): void {
+    if (!hasPendingSave || !onSave) {
+        void provider.destroy();
+        return;
+    }
+    // Capture the latest state while the Y.Doc is still alive, then push once
+    // compaction has settled.
+    const finalState = provider.getFullState();
+    void provider.destroy().then(() => onSave(finalState));
+}


### PR DESCRIPTION
Two related autosave gaps in `EditorProvider`. Both are about edits that never reach the server.

## Fix 1 — paste/first edit doesn't save (original)

**Symptom:** pasting (or the first edit) into a fresh note didn't trigger autosave; content could be lost on reload.

**Root cause:** a one-shot `skipInitial` boolean suppressed the *first* doc-changed transaction to ignore the initial Yjs hydration. On a fresh note the user's **first paste/edit is that first transaction**, so it got swallowed.

**Fix:** skip only **Yjs-originated** transactions via `ySyncPluginKey.isChangeOrigin` (initial load + remote sync), never the user's own local edits.

## Fix 2 — trailing edits saved to PGlite but not uploaded to the server

**Symptom:** the last characters typed before switching/closing a note are kept locally but never reach the server.

**Root cause:** content edits reach Homebase **only** through the 2s-debounced save — they're never marked `sync_status='pending'`, so the periodic/visibility `sync()` (which pushes only pending records) skips them; the per-note debounced `syncNote` is the sole push path. `EditorProvider` is keyed by `noteId`, so every note switch is a **full unmount**, and the cleanup cancelled the pending timer. The Yjs→PGlite write is immediate (so local has everything), but the debounced server push was dropped.

**Fix:** on teardown, **flush** the pending save instead of dropping it (`flushPendingSaveOnTeardown`). The push is deferred until `destroy()`'s compaction resolves — compaction rewrites local updates (delete-then-rewrite) and the push re-reads PGlite, so firing mid-compaction could read the empty window and clobber the note remotely.

**Tests:** `flushPendingSave.test.ts` covers the teardown ordering (state captured synchronously; push fires only after `destroy()` resolves; no-op when nothing pending). Full suite green; build clean.

**Verify**
- Fresh note → paste once → wait ~2s / reload → persists. *(Fix 1)*
- Type a few characters → immediately switch to another note → the trailing characters are on the server (e.g. open the note on another device / after a pull). *(Fix 2)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEMHL2RQH7eVNcKmWmrd6f