### PR TITLE
fix(notes): drop payload IV when syncing a public (unencrypted) note

### DIFF
--- a/src/__tests__/updateNotePublic.test.ts
+++ b/src/__tests__/updateNotePublic.test.ts
@@ -30,6 +30,8 @@ function meta(over: Partial<DocumentMetadata>): DocumentMetadata {
 // patchFile args: (client, keyHeader, instructions, uploadMetadata, payloads, ...)
 const keyHeaderArg = () => mockPatch.mock.calls[0][1];
 const uploadMeta = () => mockPatch.mock.calls[0][3];
+const payloadsArg = () => mockPatch.mock.calls[0][4];
+const yjs = () => new Uint8Array([1, 2, 3]);
 
 describe('NotesDriveProvider.updateNote — encryption/ACL by visibility', () => {
     let provider: NotesDriveProvider;
@@ -64,5 +66,24 @@ describe('NotesDriveProvider.updateNote — encryption/ACL by visibility', () =>
 
         expect(uploadMeta().isEncrypted).toBe(true);
         expect(uploadMeta().accessControlList.requiredSecurityGroup).toBe(SecurityGroupType.Connected);
+    });
+
+    // Regression: syncing a PUBLIC note's content used to attach a payload IV to an
+    // unencrypted file, which the server rejects (400 invalidUpload, "All payload IVs
+    // must be 0 bytes when server file header is not encrypted").
+    it('omits the payload IV when saving a PUBLIC note (unencrypted)', async () => {
+        await provider.updateNote(NOTE_ID, 'file-1', 'v1', meta({ isPublic: true }),
+            undefined, undefined, yjs(), fakeKeyHeader);
+
+        expect(uploadMeta().isEncrypted).toBe(false);
+        expect(payloadsArg()[0].iv).toBeUndefined();
+    });
+
+    it('attaches a payload IV when saving a PRIVATE note (encrypted)', async () => {
+        await provider.updateNote(NOTE_ID, 'file-1', 'v1', meta({ isPublic: false }),
+            undefined, undefined, yjs(), fakeKeyHeader);
+
+        expect(uploadMeta().isEncrypted).toBe(true);
+        expect(payloadsArg()[0].iv).toBeDefined();
     });
 });

--- a/src/lib/homebase/NotesDriveProvider.ts
+++ b/src/lib/homebase/NotesDriveProvider.ts
@@ -371,13 +371,17 @@ export class NotesDriveProvider {
             recipients: metadata.recipients,
             lastEditedBy: metadata.lastEditedBy,
         };
+        // A public note is stored unencrypted; the server rejects a payload IV
+        // (invalidUpload) when the file header isn't encrypted. Keep the IV and
+        // isEncrypted below driven by this one flag so they can't diverge.
+        const isEncrypted = !metadata.isPublic;
         const payloads: PayloadFile[] = [];
 
         if (yjsBlob && yjsBlob.length > 0) {
             payloads.push({
                 key: PAYLOAD_KEY_CONTENT,
                 payload: new Blob([new Uint8Array(yjsBlob)], { type: YJS_MIME_TYPE }),
-                iv: getRandom16ByteArray(),
+                iv: isEncrypted ? getRandom16ByteArray() : undefined,
             });
         }
 
@@ -410,7 +414,7 @@ export class NotesDriveProvider {
                 content: JSON.stringify(noteContent),
                 archivalStatus: metadata.archivalStatus ?? 0,
             },
-            isEncrypted: !metadata.isPublic,
+            isEncrypted,
             accessControlList,
         };
 


### PR DESCRIPTION
## Problem

Editing/syncing a **public** note failed with `400 invalidUpload`:

> All payload IVs must be 0 bytes when server file header is not encrypted

`[SyncProvider] Note sync error` on the `PATCH` upload.

## Cause

`updateNote` unconditionally stamped `getRandom16ByteArray()` on the Yjs content payload. But a public note's file header is unencrypted (`isEncrypted: !isPublic`), and the server rejects a payload IV on an unencrypted header. `addImageToNote` already gated the IV on encryption — `updateNote` didn't.

## Fix

Drive both the payload IV and `isEncrypted` from one `isEncrypted = !metadata.isPublic` flag so they can't diverge. Private/collaborative notes still get an IV; public notes don't.

## Tests

`updateNotePublic.test.ts`: the existing cases passed `yjsBlob: undefined`, so they never created a content payload and never exercised the IV. Added two cases that pass a real blob and assert IV present (private) / absent (public). All 5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)