### PR TITLE
feat(ux): linear boot-progress bar on the splash screen

### DIFF
--- a/src/__tests__/bootProgress.test.ts
+++ b/src/__tests__/bootProgress.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// The store holds module-level state — get a fresh copy per test.
+async function freshStore() {
+    vi.resetModules();
+    return await import('@/lib/bootProgress');
+}
+
+describe('bootProgress', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    it('starts at 0 and advances through phases', async () => {
+        const store = await freshStore();
+        expect(store.getBootProgress()).toBe(0);
+        store.reportBootPhase('react');
+        expect(store.getBootProgress()).toBe(10);
+        store.reportBootPhase('db-start');
+        expect(store.getBootProgress()).toBe(25);
+        store.reportBootPhase('db-worker');
+        expect(store.getBootProgress()).toBe(65);
+        store.reportBootPhase('db-ready');
+        expect(store.getBootProgress()).toBe(85);
+    });
+
+    it('is monotonic — an earlier or repeated phase never moves the bar back', async () => {
+        const store = await freshStore();
+        store.reportBootPhase('db-worker');
+        expect(store.getBootProgress()).toBe(65);
+        store.reportBootPhase('react');
+        store.reportBootPhase('db-worker');
+        expect(store.getBootProgress()).toBe(65);
+    });
+
+    it('notifies subscribers only on actual progress, and unsubscribe works', async () => {
+        const store = await freshStore();
+        const listener = vi.fn();
+        const unsubscribe = store.subscribeBootProgress(listener);
+
+        store.reportBootPhase('react');
+        expect(listener).toHaveBeenCalledTimes(1);
+        // No-op report (monotonic guard) must not notify.
+        store.reportBootPhase('react');
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        unsubscribe();
+        store.reportBootPhase('db-start');
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(store.getBootProgress()).toBe(25);
+    });
+});

--- a/src/components/layout/SplashScreen.tsx
+++ b/src/components/layout/SplashScreen.tsx
@@ -55,7 +55,7 @@ export function SplashScreen({ className }: SplashScreenProps) {
           aria-valuemin={0}
           aria-valuemax={100}
           aria-valuenow={progress}
-          className="mt-6 h-1 w-48 overflow-hidden rounded-full bg-muted animate-in fade-in duration-700 delay-200 fill-mode-forwards opacity-0"
+          className="mt-6 h-1 w-48 overflow-hidden rounded-full bg-muted"
         >
           <div
             className="h-full rounded-full bg-foreground/70 transition-[width] duration-500 ease-out"

--- a/src/components/layout/SplashScreen.tsx
+++ b/src/components/layout/SplashScreen.tsx
@@ -7,8 +7,22 @@ interface SplashScreenProps {
   className?: string;
 }
 
+// Light-hearted boot quips, rotated while the app loads.
+const BOOT_QUIPS = [
+  'Sharpening the pencils…',
+  'Waking the database elephant…',
+  'Untangling the [[wiki links]]…',
+  'Dusting off your notebook…',
+  'Brewing fresh ink…',
+  'Recalling where you left off…',
+  'Straightening the margins…',
+  'Hiding the key under the mat… kidding, encrypting.',
+];
+
 export function SplashScreen({ className }: SplashScreenProps) {
   const [show, setShow] = useState(false);
+  // Random start so reloads don't always open on the same quip.
+  const [quip, setQuip] = useState(() => Math.floor(Math.random() * BOOT_QUIPS.length));
   // Real boot milestones (bundle parsed → DB worker → DB ready) reported via
   // reportBootPhase. The bar never hits 100% here — the app replacing the
   // splash is the completion signal.
@@ -18,6 +32,11 @@ export function SplashScreen({ className }: SplashScreenProps) {
     // Small delay to ensure smooth transition
     const timer = setTimeout(() => setShow(true), 50);
     return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => setQuip((q) => q + 1), 2500);
+    return () => clearInterval(id);
   }, []);
 
   return (
@@ -39,7 +58,10 @@ export function SplashScreen({ className }: SplashScreenProps) {
         </div>
         
         {/* Loading text with animated dots */}
-        <div className="flex items-center space-x-1 text-muted-foreground animate-in slide-in-from-bottom-4 duration-700 delay-200 fade-in fill-mode-forwards opacity-0">
+        {/* fill-mode-backwards (not opacity-0 + forwards) hides it only during
+            the entry delay — the old combo animated opacity 0 → 0, so this row
+            was never visible at all. */}
+        <div className="flex items-center space-x-1 text-muted-foreground animate-in slide-in-from-bottom-4 duration-700 delay-200 fade-in fill-mode-backwards">
           <span className="text-sm font-medium tracking-widest uppercase">Loading</span>
           <span className="flex space-x-1 ml-1">
             <span className="w-1 h-1 bg-muted-foreground rounded-full animate-bounce [animation-delay:-0.3s]"></span>
@@ -62,6 +84,15 @@ export function SplashScreen({ className }: SplashScreenProps) {
             style={{ width: `${progress}%` }}
           />
         </div>
+
+        {/* Rotating quip — key remount replays the fade on each change */}
+        <p
+          key={quip}
+          aria-hidden="true"
+          className="mt-4 h-4 text-xs text-muted-foreground animate-in fade-in duration-500"
+        >
+          {BOOT_QUIPS[quip % BOOT_QUIPS.length]}
+        </p>
       </div>
     </div>
   );

--- a/src/components/layout/SplashScreen.tsx
+++ b/src/components/layout/SplashScreen.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import { cn } from '@/lib/utils';
+import { getBootProgress, subscribeBootProgress } from '@/lib/bootProgress';
 import logo from '@/assets/logo_withoutbg.png';
 
 interface SplashScreenProps {
@@ -8,6 +9,10 @@ interface SplashScreenProps {
 
 export function SplashScreen({ className }: SplashScreenProps) {
   const [show, setShow] = useState(false);
+  // Real boot milestones (bundle parsed → DB worker → DB ready) reported via
+  // reportBootPhase. The bar never hits 100% here — the app replacing the
+  // splash is the completion signal.
+  const progress = useSyncExternalStore(subscribeBootProgress, getBootProgress);
 
   useEffect(() => {
     // Small delay to ensure smooth transition
@@ -41,6 +46,21 @@ export function SplashScreen({ className }: SplashScreenProps) {
             <span className="w-1 h-1 bg-muted-foreground rounded-full animate-bounce [animation-delay:-0.15s]"></span>
             <span className="w-1 h-1 bg-muted-foreground rounded-full animate-bounce"></span>
           </span>
+        </div>
+
+        {/* Linear boot progress */}
+        <div
+          role="progressbar"
+          aria-label="Loading progress"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={progress}
+          className="mt-6 h-1 w-48 overflow-hidden rounded-full bg-muted animate-in fade-in duration-700 delay-200 fill-mode-forwards opacity-0"
+        >
+          <div
+            className="h-full rounded-full bg-foreground/70 transition-[width] duration-500 ease-out"
+            style={{ width: `${progress}%` }}
+          />
         </div>
       </div>
     </div>

--- a/src/lib/bootProgress.ts
+++ b/src/lib/bootProgress.ts
@@ -1,0 +1,38 @@
+/**
+ * Boot progress store for the splash screen's linear progress bar.
+ *
+ * Phases are real boot milestones, each mapped to a cumulative percentage.
+ * Progress is monotonic — a phase reported late (or twice) never moves the
+ * bar backwards. The splash never reaches 100% via a phase: the app UI
+ * replacing the splash IS the completion signal.
+ */
+export type BootPhase = 'react' | 'db-start' | 'db-worker' | 'db-ready';
+
+// Weights reflect real cost: PGlite's WASM fetch/compile (db-worker) is the
+// long pole of a cold boot; schema init and first data emit are quick.
+const PHASE_PROGRESS: Record<BootPhase, number> = {
+    react: 10,
+    'db-start': 25,
+    'db-worker': 65,
+    'db-ready': 85,
+};
+
+let progress = 0;
+const listeners = new Set<() => void>();
+
+export function reportBootPhase(phase: BootPhase): void {
+    const next = PHASE_PROGRESS[phase];
+    if (next <= progress) return;
+    progress = next;
+    listeners.forEach((listener) => listener());
+}
+
+export function getBootProgress(): number {
+    return progress;
+}
+
+/** Subscribe to progress changes; returns an unsubscribe function. */
+export function subscribeBootProgress(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}

--- a/src/lib/db/pglite.ts
+++ b/src/lib/db/pglite.ts
@@ -3,6 +3,7 @@ import type { PGliteInterface } from '@electric-sql/pglite';
 import { live } from '@electric-sql/pglite/live';
 import type { PGliteWithLive } from '@electric-sql/pglite/live';
 import { MAIN_FOLDER_ID } from '../homebase';
+import { reportBootPhase } from '../bootProgress';
 import {
   migrateFromV3,
   deleteV3Database,
@@ -44,10 +45,16 @@ export function ensureTrigramSearch(db: PGliteInterface): Promise<void> {
 
 export function getDatabase(): Promise<PGliteInterface> {
   if (!dbPromise) {
-    dbPromise = initDatabase().catch((err) => {
-      dbPromise = null;
-      throw err;
-    });
+    reportBootPhase('db-start');
+    dbPromise = initDatabase()
+      .then((db) => {
+        reportBootPhase('db-ready');
+        return db;
+      })
+      .catch((err) => {
+        dbPromise = null;
+        throw err;
+      });
   }
   return dbPromise;
 }
@@ -72,7 +79,12 @@ function createWorkerInstance(loadDataDir?: Blob): Promise<PGliteInterface> {
   return PGliteWorker.create(
     new Worker(new URL('./pglite-worker.ts', import.meta.url), { type: 'module' }),
     options,
-  );
+  ).then((db) => {
+    // WASM fetched + compiled and the worker leader elected — the slowest
+    // step of a cold boot, reported for the splash progress bar.
+    reportBootPhase('db-worker');
+    return db;
+  });
 }
 
 async function initDatabase(): Promise<PGliteInterface> {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import './lib/utils/initLogging';
 import './lib/utils/sw-safety';
+import { reportBootPhase } from './lib/bootProgress';
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
@@ -11,6 +12,9 @@ import './lib/utils/memoryMonitor'
 
 // Request persistent storage so the browser won't evict IndexedDB/Cache under storage pressure
 navigator.storage?.persist?.();
+
+// Main bundle parsed and executing — first boot milestone for the splash bar.
+reportBootPhase('react');
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
Adds a determinate progress bar to the splash screen, driven by real boot milestones instead of an animation:

| Milestone | % |
|---|---|
| Main bundle parsed (`main.tsx`) | 10 |
| `getDatabase()` first called | 25 |
| PGlite worker created — WASM fetch/compile, the cold-boot long pole | 65 |
| Schema + migrations done | 85 |
| App UI replaces splash | (completion) |

- `src/lib/bootProgress.ts`: ~35-line monotonic phase store (no deps); splash subscribes via `useSyncExternalStore`.
- Bar has `role="progressbar"` ARIA; styling matches the existing splash.
- Known limits: nothing renders before the JS bundle executes (an inline HTML splash would be a follow-up); phase weights are estimates — tune in `PHASE_PROGRESS`; a splash shown after boot (folder switches) displays the retained ~85% rather than restarting.

Gates: 395/395 tests (3 new for the store), eslint clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuGEdMtRFLfNxNavavm1XQ