### PR TITLE
feat(notes): add "Open in Owner Console" context-menu item

### DIFF
--- a/src/__tests__/ownerConsoleUrl.test.ts
+++ b/src/__tests__/ownerConsoleUrl.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { ownerConsoleNoteUrl, JOURNAL_DRIVE } from '@/lib/homebase/config';
+
+describe('ownerConsoleNoteUrl', () => {
+    it('composes the Owner Console drive deep link', () => {
+        expect(
+            ownerConsoleNoteUrl('https://bishwajeetparhi.dev', '5837f419-a07e-9d00-e198-80565c4f0874'),
+        ).toBe(
+            'https://bishwajeetparhi.dev/owner/drives/d5f411fa83fd4854a3bd7e974cc9bca9_30743710039d4b97bbd352f343d1c9df/5837f419-a07e-9d00-e198-80565c4f0874',
+        );
+    });
+
+    it('uses the drive alias/type as stored — hex, no dashes', () => {
+        expect(JOURNAL_DRIVE.alias).not.toContain('-');
+        expect(JOURNAL_DRIVE.type).not.toContain('-');
+    });
+});

--- a/src/components/layout/NoteList.tsx
+++ b/src/components/layout/NoteList.tsx
@@ -12,7 +12,10 @@ import {
   ChevronDown,
   ChevronRight,
   ArrowUpDown,
+  ExternalLink,
 } from "lucide-react";
+import { useDotYouClientContext } from "@/components/auth";
+import { ownerConsoleNoteUrl } from "@/lib/homebase";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -297,6 +300,7 @@ const NoteItem = memo(function NoteItem({
   onMarkCollaborative?: (note: NoteListEntry) => void;
   onArchive?: (note: NoteListEntry) => void;
 }) {
+  const dotYouClient = useDotYouClientContext();
   const touchStartRef = useRef<number | null>(null);
   const touchEndRef = useRef<number | null>(null);
   const [isSwiped, setIsSwiped] = useState(false);
@@ -386,6 +390,16 @@ const NoteItem = memo(function NoteItem({
             label: "Share",
             icon: Share2,
             action: () => onShareNote(note),
+          },
+          {
+            label: "Open in Owner Console",
+            icon: ExternalLink,
+            action: () =>
+              window.open(
+                ownerConsoleNoteUrl(dotYouClient.getRoot(), note.docId),
+                "_blank",
+                "noopener,noreferrer",
+              ),
           },
           {
             label: note.metadata.isCollaborative

--- a/src/lib/homebase/config.ts
+++ b/src/lib/homebase/config.ts
@@ -37,6 +37,14 @@ export const JOURNAL_DRIVE: TargetDrive = {
     type: '30743710039d4b97bbd352f343d1c9df',
 };
 
+/**
+ * Owner Console deep link for a note. `docId` is the Homebase `uniqueId`, which the
+ * console accepts in place of a numeric fileId. `root` must come from
+ * `dotYouClient.getRoot()` — the app is deployed cross-site, so window.location is wrong.
+ */
+export const ownerConsoleNoteUrl = (root: string, docId: string) =>
+    `${root}/owner/drives/${JOURNAL_DRIVE.alias}_${JOURNAL_DRIVE.type}/${docId}`;
+
 export const MAIN_FOLDER_ID = '06cf9262-4eae-4276-b0d1-8ca3cf5be6f4';
 export const COLLABORATIVE_FOLDER_ID = 'fc360190-4e23-b870-0ea4-ef233aad98ad'; // For shared/collaborative notes V2
 


### PR DESCRIPTION
Closes #81

Right-click a note → **Open in Owner Console** opens `{root}/owner/drives/{alias}_{type}/{docId}` in a new tab.

## Changes
- `src/lib/homebase/config.ts` — one-line `ownerConsoleNoteUrl(root, docId)` helper (testable seam).
- `src/components/layout/NoteList.tsx` — menu item in `NoteItem`, reading `dotYouClient.getRoot()` from context.
- `src/__tests__/ownerConsoleUrl.test.ts` — asserts the composed URL matches the console format byte-for-byte.

## Notes
- Skipped the prop-threading from `JournalLayout` the issue suggested — `NoteItem` can read `useDotYouClientContext()` directly, so this is one file instead of two and no new props.
- `getRoot()` (not `window.location.origin`): the app is deployed cross-site at `journal.cloudx.run`, the console lives on the identity domain.

## Verification
- `npx vitest run src/__tests__/ownerConsoleUrl.test.ts` → 2 passed
- `npm run build` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)