### PR TITLE
fix(sync): drop the cached key header when a note's visibility flips

### DIFF
--- a/src/__tests__/makeNotePublic.test.ts
+++ b/src/__tests__/makeNotePublic.test.ts
@@ -81,6 +81,16 @@ describe('NotesDriveProvider.makeNotePublic', () => {
         expect(metadata.accessControlList.requiredSecurityGroup).toBe(SecurityGroupType.Anonymous);
         expect(mockReUpload.mock.calls[0][3]).toBe(false); // encrypt flag
     });
+
+    // allowDistribution governs peer/feed distribution, not public readability —
+    // the Anonymous ACL is what makes the note world-readable.
+    it('does not flag the note for peer/feed distribution', async () => {
+        mockGetHeader.mockResolvedValue(ownerHeader());
+
+        await provider.makeNotePublic(NOTE_ID);
+
+        expect(mockReUpload.mock.calls[0][2].allowDistribution).toBe(false);
+    });
 });
 
 describe('NotesDriveProvider.makeNotePrivate', () => {

--- a/src/__tests__/trashNote.test.ts
+++ b/src/__tests__/trashNote.test.ts
@@ -83,6 +83,19 @@ describe('NotesDriveProvider.setNoteArchivalStatus', () => {
         expect(mockPatchFile.mock.calls[0][3].appData.archivalStatus).toBe(0);
     });
 
+    // allowDistribution is peer/feed distribution, not readability: trashing a
+    // public (Anonymous) note must not flag it for distribution.
+    it('never flags the file for peer/feed distribution', async () => {
+        mockGetHeader.mockResolvedValue({
+            ...ownerHeader(),
+            serverMetadata: { accessControlList: { requiredSecurityGroup: SecurityGroupType.Anonymous } },
+        });
+
+        await provider.setNoteArchivalStatus(NOTE_ID, 2);
+
+        expect(mockPatchFile.mock.calls[0][3].allowDistribution).toBe(false);
+    });
+
     it('reads the header decrypted so the patched content stays valid', async () => {
         mockGetHeader.mockResolvedValue(ownerHeader());
 

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -13,6 +13,7 @@ import {
     getTrashedNotes,
     getSearchIndexEntry,
     setNoteArchivalStatusLocal,
+    clearCachedKeyHeader,
     NOTE_LIST_SQL,
     NOTE_ROW_KEY,
     NOTE_COUNTS_SQL,
@@ -365,6 +366,12 @@ export function useNotes() {
 
             const updatedMetadata = { ...current.metadata, isPublic };
             await updateSearchIndexMetadata(docId, current.title, updatedMetadata);
+            // Both makeNotePublic and makeNotePrivate re-upload the file, which re-keys
+            // it (public = no key header at all, private = a brand-new one). The cached
+            // header is now the WRONG key — validateKeyHeader only checks shape, so the
+            // next push would happily encrypt the payload with it and every later read
+            // would fail decryption ("OperationError" / "operation not permitted").
+            await clearCachedKeyHeader(docId);
         },
     });
 

--- a/src/lib/homebase/NotesDriveProvider.ts
+++ b/src/lib/homebase/NotesDriveProvider.ts
@@ -656,7 +656,10 @@ export class NotesDriveProvider {
         // Update metadata with Anonymous access control, preserving note content.
         const uploadMetadata: UploadFileMetadata = {
             versionTag,
-            allowDistribution: true, // Allow distribution for public access
+            // Peer/feed distribution only — unrelated to the Anonymous ACL that makes
+            // the note publicly readable. See FileSystemUpdateWriterBase ("AllowDistribution
+            // must be true when UpdateLocale is Peer") and FeedDriveDistributionRouter.
+            allowDistribution: false,
             appData: {
                 fileType: JOURNAL_FILE_TYPE,
                 dataType: JOURNAL_DATA_TYPE,
@@ -779,9 +782,10 @@ export class NotesDriveProvider {
 
         const uploadMetadata: UploadFileMetadata = {
             versionTag: existingHeader.fileMetadata.versionTag,
-            // Match the note's creation default: only public (Anonymous) notes distribute.
-            allowDistribution:
-                accessControlList.requiredSecurityGroup === SecurityGroupType.Anonymous,
+            // Peer/feed distribution only; an Anonymous ACL does not imply it. A fetched
+            // header omits serverMetadata.allowDistribution, so there is nothing to
+            // preserve — match every other local (non-peer) write and send false.
+            allowDistribution: false,
             appData: {
                 fileType: JOURNAL_FILE_TYPE,
                 dataType: JOURNAL_DATA_TYPE,


### PR DESCRIPTION
Refs #80

## What the error actually is
"operation not permitted" is **WebCrypto**, not the server. The string exists nowhere in DotYouCore, dotyoucore-js, `@homebase-id/js-lib`, or this app (backend 403s are titled `Forbidden: <msg>`). It is WebKit's wording for a `DOMException: OperationError` out of `crypto.subtle.decrypt` — reached via `decryptKeyHeader` → `cbcDecrypt` (`SecurityHelpers.ts:261`).

## Root cause
`makeNotePublic` and `makeNotePrivate` both go through `reUploadFile`, which **re-keys the file**: public drops the key header entirely, private gets a brand-new one. Nothing cleared the sync record's `encrypted_key_header`, and `validateKeyHeader` only checks *shape* — so the stale header survived, and the next `pushNote` handed it to `patchFile`, encrypting the payload under the wrong AES key. The note then can't be decrypted with the file's real key header → `OperationError`, forever.

`a6f4c62` clears the header *reactively* after the error; this clears it at the moment the key actually changes.

## Changes
- `src/hooks/useNotes.ts` — `setNotePublic` (the mutation both ShareDialog actions call) now clears the cached key header after flipping visibility.
- `src/lib/homebase/NotesDriveProvider.ts` — `allowDistribution` corrected on the two public-note write paths, per your note that it is **peer-only**: `makeNotePublic` was sending `true`, `setNoteArchivalStatus` was deriving it from an Anonymous ACL. Both send `false` now, like every other local write. Verified against DotYouCore: `FileSystemUpdateWriterBase.cs:282` ("AllowDistribution must be true when UpdateLocale is Peer") and `FeedDriveDistributionRouter.cs:191`; no ACL/permission check reads it. Note a fetched header omits `serverMetadata.allowDistribution`, so there is nothing to preserve.
- Tests in `makeNotePublic.test.ts` / `trashNote.test.ts` pin the distribution flag (both fail without the change).

## Verification
- `npm run test` → 399 passed (50 files); `npm run build` → clean.
- **Not verified against a live drive.** The mocked suite can't reproduce a crypto failure. Worth confirming by making a note public, editing it, and reloading.

## Left open, deliberately
- The `useNotes` wiring has no test seam — the suite runs in node with no React renderer.
- The stale `versionTag` after publishing is *not* persisted: `onVersionConflict` already refetches and retries, so it self-heals at the cost of one round-trip.
- The other half of this cluster — the local `isPublic` flag being dropped so a push takes the encrypted branch on a public file — is #79 / PR #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)