### PR TITLE
fix(sw): precache the app shell as / so share links stop failing

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -80,6 +80,18 @@ jobs:
         env:
           CI: true
 
+      # Pages 308s /index.html -> /, and a redirected response served to a
+      # navigation is a hard network error — every share link dies with "This
+      # site can't be reached". Guarded here because it only breaks on Pages.
+      - name: Verify service worker precaches the canonical shell URL
+        run: |
+          grep -q '"url":"/"' dist/sw.js \
+            || { echo "::error::sw.js must precache '/' — see manifestTransforms in vite.config.ts"; exit 1; }
+          if grep -q '"url":"index.html"' dist/sw.js; then
+            echo "::error::sw.js precaches index.html, which Cloudflare Pages 308s to /"
+            exit 1
+          fi
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -203,7 +203,12 @@ registerRoute(
 // SPA Navigation Fallback: Serve index.html for all navigation requests
 // This is essential for the PWA to work offline on non-root paths
 registerRoute(
-    new NavigationRoute(createHandlerBoundToURL('/index.html'), {
+    // '/' not '/index.html': Cloudflare Pages 308s /index.html -> /, and a
+    // redirected response served to a navigation is a network error. The
+    // precache manifest is rewritten to match by manifestTransforms in
+    // vite.config.ts — these two must change together, or this call throws at
+    // service-worker startup.
+    new NavigationRoute(createHandlerBoundToURL('/'), {
         denylist: [
             /^\/api\//, // Exclude API calls
             /^\/img\//, // Exclude images if needed

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,6 +91,22 @@ export default defineConfig(({ mode }) => ({
           '**/pglite-COscPi1Y.data',
         ],
         maximumFileSizeToCacheInBytes: 15 * 1024 * 1024, // 15 MB for large WASM files
+        // Cloudflare Pages canonicalizes /index.html -> / with a 308, so every
+        // fetch of the precached shell (install, and PrecacheStrategy's network
+        // fallback on a cache miss) comes back with response.redirected = true.
+        // Serving a redirected response to a navigation — whose redirect mode is
+        // "manual" — is a hard network error, i.e. "This site can't be reached"
+        // on any cold precache. Precaching the shell under its canonical URL
+        // keeps the response redirect-free. Must stay in sync with
+        // createHandlerBoundToURL('/') in src/sw.ts.
+        manifestTransforms: [
+          (entries) => ({
+            manifest: entries.map((e) =>
+              e.url === 'index.html' ? { ...e, url: '/' } : e
+            ),
+            warnings: [],
+          }),
+        ],
       },
       devOptions: {
         enabled: false, // Disable in dev to avoid cache errors


### PR DESCRIPTION
Fixes #105.

Every share link could die with Chrome's **"This site can't be reached"** (`ERR_FAILED`). The server was never at fault — the service worker was.

## Cause

Cloudflare Pages canonicalizes `/index.html` → `/` with a **308**:

```console
$ curl -o /dev/null -w "%{http_code} -> %{redirect_url}\n" https://journal.cloudx.run/index.html
308 -> https://journal.cloudx.run/
```

Workbox precached the shell under `index.html`, so a fetch of it returns a response with `redirected: true`. A navigation request has redirect mode `"manual"`, and serving it a redirected response is a **hard network error**.

The install-time copy is fine — `copyRedirectedCacheableResponsesPlugin` strips the flag, which I confirmed in the browser. The failing path is `PrecacheStrategy`'s **network fallback on a cache miss** (eviction, storage pressure, cold precache). That's why it hit intermittently, and hardest on share links: their audience is always first-time visitors.

## Fix

Precache the shell under its canonical URL so nothing ever requests `/index.html`:

- `vite.config.ts` — `manifestTransforms` rewrites the `index.html` entry to `/`
- `src/sw.ts` — `createHandlerBoundToURL('/')`

These must move together, or `createHandlerBoundToURL` throws at service-worker startup. A CI step between build and deploy fails the deploy if they drift.

## Verification

Tested in a real browser against a local server that reproduces the Pages 308, with the SW controlling and the shell entry evicted to simulate a cold precache:

| | pre-fix | post-fix |
|---|---|---|
| Precache shell key | `/index.html?__WB_REVISION__=…` (308s) | `/?__WB_REVISION__=…` (200) |
| Navigate to a share link | **`ERR_FAILED` — "This site can't be reached"** | **note renders** |

Also confirmed:

- Fresh install: 85 precache entries, shell cached at `/?__WB_REVISION__=…` with `redirected: false`, zero `index.html` entries
- Offline: killed the server, a deep route still served the app shell
- `npm run test` → 416 passed / 52 files
- The CI guard passes on this build and fails on a pre-fix build (checked both directions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)