### PR TITLE
perf(boot): warm-start PGlite and skip app boot work on public share pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {
 import { SyncProvider } from "@/components/providers/SyncProvider";
 import { OnlineProvider } from "@/components/providers/OnlineProvider";
 import { UpdatePrompt } from "@/components/pwa/UpdatePrompt";
+import { isPublicSharePath } from "@/lib/utils";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -111,7 +112,12 @@ function App() {
           </BrowserRouter>
 
           <Toaster />
-          <UpdatePrompt />
+          {/* Mounting this registers the service worker, which precaches the
+              whole ~18 MB app shell. A public share visitor reads one note and
+              leaves, so they neither need the offline shell nor an update
+              prompt. Evaluated once at mount: a share visitor who navigates
+              into the app gets the SW on their next full load. */}
+          {!isPublicSharePath() && <UpdatePrompt />}
         </ErrorBoundary>
       </PersistQueryClientProvider>
     </MotionConfig>

--- a/src/__tests__/bootProgress.test.ts
+++ b/src/__tests__/bootProgress.test.ts
@@ -22,6 +22,48 @@ describe('bootProgress', () => {
         expect(store.getBootProgress()).toBe(65);
         store.reportBootPhase('db-ready');
         expect(store.getBootProgress()).toBe(85);
+        store.reportBootPhase('notes-rendered');
+        expect(store.getBootProgress()).toBe(95);
+    });
+
+    it('logs the db-start → first note timing once the note list renders', async () => {
+        const store = await freshStore();
+        const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+        const now = vi.spyOn(performance, 'now');
+
+        now.mockReturnValue(100);
+        store.reportBootPhase('react');
+        now.mockReturnValue(200);
+        store.reportBootPhase('db-start');
+        now.mockReturnValue(1800);
+        store.reportBootPhase('db-worker');
+        now.mockReturnValue(2000);
+        store.reportBootPhase('db-ready');
+        expect(log).not.toHaveBeenCalled();
+
+        now.mockReturnValue(2300);
+        store.reportBootPhase('notes-rendered');
+        // The line is emitted from a promise chain so the storage estimate can
+        // ride along with it — let that microtask settle before asserting.
+        await Promise.resolve();
+        expect(log).toHaveBeenCalledTimes(1);
+        expect(log.mock.calls[0][0]).toContain('db-start → first note: 2100ms');
+        expect(log.mock.calls[0][1]).toEqual({
+            react: 100,
+            dbStart: 200,
+            dbWorker: 1800,
+            dbReady: 2000,
+            firstNote: 2300,
+            storageMB: null,
+        });
+
+        // Monotonic guard: a repeat report must not log a second time.
+        store.reportBootPhase('notes-rendered');
+        await Promise.resolve();
+        expect(log).toHaveBeenCalledTimes(1);
+
+        log.mockRestore();
+        now.mockRestore();
     });
 
     it('is monotonic — an earlier or repeated phase never moves the bar back', async () => {

--- a/src/__tests__/isPublicSharePath.test.ts
+++ b/src/__tests__/isPublicSharePath.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { isPublicSharePath } from '@/lib/utils';
+
+// This predicate gates the PGlite warm-start, persistent-storage request and
+// service-worker registration (main.tsx, App.tsx). A false positive would boot
+// an authenticated app route without its database.
+describe('isPublicSharePath', () => {
+    it('matches a public share note', () => {
+        expect(isPublicSharePath('/share/bishwajeetparhi.dev/e5b899be')).toBe(true);
+    });
+
+    it('does not match /share-target — that is an authenticated app route', () => {
+        expect(isPublicSharePath('/share-target')).toBe(false);
+    });
+
+    it('does not match ordinary app routes', () => {
+        for (const path of ['/', '/inbox', '/inbox/note-1', '/welcome', '/auth/finalize']) {
+            expect(isPublicSharePath(path)).toBe(false);
+        }
+    });
+});

--- a/src/layouts/JournalLayout.tsx
+++ b/src/layouts/JournalLayout.tsx
@@ -20,6 +20,7 @@ import {
   useKeyboardShortcuts,
 } from "@/hooks";
 import { cn } from "@/lib/utils";
+import { reportBootPhase } from "@/lib/bootProgress";
 import { useState, useEffect, useRef, lazy, Suspense, useMemo, useCallback, Activity } from "react";
 import { ChevronLeft, Minimize2, Maximize2, ArchiveRestore, Trash2, Archive } from "lucide-react";
 import { Kbd } from "@/components/ui/kbd";
@@ -115,6 +116,12 @@ export default function JournalLayout() {
 
   // Homebase sync - auto-syncs on mount and focus
   useSyncService();
+
+  // Last boot milestone: the first commit that renders the note list instead of
+  // the splash. Closes the db-start → first note measurement (bootProgress).
+  useEffect(() => {
+    if (!isNotesLoading && !isFolderLoading) reportBootPhase("notes-rendered");
+  }, [isNotesLoading, isFolderLoading]);
 
   const dotYouClient = useDotYouClientContext();
 

--- a/src/lib/bootProgress.ts
+++ b/src/lib/bootProgress.ts
@@ -6,7 +6,7 @@
  * bar backwards. The splash never reaches 100% via a phase: the app UI
  * replacing the splash IS the completion signal.
  */
-export type BootPhase = 'react' | 'db-start' | 'db-worker' | 'db-ready';
+export type BootPhase = 'react' | 'db-start' | 'db-worker' | 'db-ready' | 'notes-rendered';
 
 // Weights reflect real cost: PGlite's WASM fetch/compile (db-worker) is the
 // long pole of a cold boot; schema init and first data emit are quick.
@@ -15,16 +15,45 @@ const PHASE_PROGRESS: Record<BootPhase, number> = {
     'db-start': 25,
     'db-worker': 65,
     'db-ready': 85,
+    'notes-rendered': 95,
 };
 
 let progress = 0;
 const listeners = new Set<() => void>();
 
+// Timestamp (ms since navigation start) of the first time each phase was
+// reported. Boot is a one-shot sequence, so the whole cold-start profile —
+// including the db-start → first note critical path — reads off these.
+const phaseTimes: Partial<Record<BootPhase, number>> = {};
+
 export function reportBootPhase(phase: BootPhase): void {
     const next = PHASE_PROGRESS[phase];
     if (next <= progress) return;
+    phaseTimes[phase] = performance.now();
     progress = next;
+    if (phase === 'notes-rendered') logBootTimings();
     listeners.forEach((listener) => listener());
+}
+
+/** Cold-boot profile, logged once when the note list first renders. */
+function logBootTimings(): void {
+    const mark = (phase: BootPhase) => Math.round(phaseTimes[phase] ?? 0);
+    const line = `[Boot] db-start → first note: ${mark('notes-rendered') - mark('db-start')}ms`;
+    const marks = {
+        react: mark('react'),
+        dbStart: mark('db-start'),
+        dbWorker: mark('db-worker'),
+        dbReady: mark('db-ready'),
+        firstNote: mark('notes-rendered'),
+    };
+    // Origin bytes, logged alongside the timings so the two can be correlated
+    // across boots: PGlite reads its whole data dir out of IndexedDB before
+    // Postgres accepts a query, so if this grows and dbWorker grows with it,
+    // the IDB sync is the long pole. If this stays small while dbWorker stays
+    // slow, it's the 8.7 MB WASM compile and no amount of VACUUM would help.
+    Promise.resolve(navigator.storage?.estimate?.())
+        .then((est) => console.log(line, { ...marks, storageMB: est?.usage ? +(est.usage / 1048576).toFixed(1) : null }))
+        .catch(() => console.log(line, marks));
 }
 
 export function getBootProgress(): number {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -96,3 +96,15 @@ export const toArrayBufferBackedView = (bytes: Uint8Array<ArrayBufferLike>): Uin
   copy.set(bytes);
   return copy;
 };
+
+/**
+ * A public share page is a one-shot anonymous read of someone else's note: it
+ * never touches the local DB and there is nothing worth keeping offline. Used
+ * to skip the app-scoped boot work (PGlite warm-start, persistent storage,
+ * service-worker install) for visitors who will never benefit from it.
+ *
+ * Matches `/share/:identity/:noteId` only — `/share-target` is an authenticated
+ * app route and must keep the full boot.
+ */
+export const isPublicSharePath = (pathname = location.pathname): boolean =>
+  pathname.startsWith('/share/');

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import './lib/utils/initLogging';
 import './lib/utils/sw-safety';
 import { reportBootPhase } from './lib/bootProgress';
+import { isPublicSharePath } from './lib/utils';
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
@@ -10,11 +11,23 @@ import App from './App.tsx'
 // Import memory monitor for dev debugging (exposes window.memoryMonitor)
 import './lib/utils/memoryMonitor'
 
-// Request persistent storage so the browser won't evict IndexedDB/Cache under storage pressure
-navigator.storage?.persist?.();
-
 // Main bundle parsed and executing — first boot milestone for the splash bar.
 reportBootPhase('react');
+
+// A public share page reads one note over the network and nothing else, so it
+// skips both of these: no local database to warm, nothing to keep offline.
+if (!isPublicSharePath()) {
+    // Request persistent storage so the browser won't evict IndexedDB/Cache under storage pressure
+    navigator.storage?.persist?.();
+
+    // Warm-start PGlite. Every query sits behind AuthGuard, so without this the
+    // 8.8 MB WASM fetch/compile only begins after the auth round-trip resolves.
+    // getDatabase() is an idempotent cached promise, so the first real query just
+    // awaits this already-running boot. A failure clears that cached promise, so
+    // the real query path re-inits and surfaces its own error — this catch only
+    // exists to keep the fire-and-forget call from raising an unhandled rejection.
+    import('./lib/db/pglite').then((m) => m.getDatabase()).catch(() => {});
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
Addresses **section 1 only** of #103. Draft on purpose: the fix is unmeasured, and this PR also ships the instrumentation that would measure it.

## What changed

**Warm-start.** Every DB query sits behind `AuthGuard`, so the 8.7 MB WASM fetch/compile only began *after* the auth round-trip resolved. `src/main.tsx` now kicks `getDatabase()` off at module scope, overlapping that work with React mount and auth rather than queuing behind it.

Safety was verified against the real code, not assumed: `getDatabase()` nulls its own cached promise on rejection (`src/lib/db/pglite.ts:53-56`), so a failed warm-up cannot poison the later real query — the next call re-inits and surfaces its own error. The `.catch(() => {})` only silences the warm-start's own copy of the rejection.

**Measurement.** A `notes-rendered` phase closes a `db-start → first note` timing, logged once when the note list first paints, with the phase marks and `navigator.storage.estimate()` usage:

```
[Boot] db-start → first note: 2100ms { react, dbStart, dbWorker, dbReady, firstNote, storageMB }
```

`console.log` is no-op'd in production by `initLogging.ts` unless the Homebase debug flag is set, so this is always-on in dev and debug-gated in prod.

**Public share pages opt out.** An anonymous visitor reading one shared note no longer pays for: the PGlite warm-start (no 8.7 MB compile, no `idb://journal-db` data dir created on a device that never queries it), `navigator.storage.persist()`, or service-worker registration (`<UpdatePrompt />` is what calls `useRegisterSW`, so this also skips the ~18 MB app-shell precache).

`isPublicSharePath` matches `/share/` **with the trailing slash** so `/share-target` — an authenticated route behind `AuthGuard` — keeps its full boot. That's the one way this could go wrong, so it has a test.

## Deliberately NOT done

**Section 2 (VACUUM)** and **section 3 (`pg_trgm`)** are not implemented. A static review found:

- **§2's proposed fix cannot work as written.** Boot cost is a function of bytes in IndexedDB, and plain `VACUUM` does not shrink files — it marks space reusable inside existing pages. Only `VACUUM FULL` shrinks, and it rewrites every table into new files that then flow *back* through IDBFS, writing a second full copy of every note into IndexedDB before dropping the old. The mechanism the issue describes is real (and worse than written — compaction's dominant trigger is `destroy()` on every note switch, `provider.ts:228`, not the 50-update threshold), but the remedy doesn't follow.
- **§3 is real but not worth it.** PGlite 0.4.4 does eagerly fetch, untar and instantiate the extension at construction (`pglite.ts:544`, awaited before Postgres starts). But `pg_trgm.tar.gz` is **15,178 bytes against an 8.74 MB wasm** — 0.17% — and the fetch is started early and awaited late, so it overlaps the main compile. Removing it makes `ensureTrigramSearch()` throw, dropping Cmd+K through to the LIKE-only `fallbackSearch` (`queries.ts:730`) and losing tsvector ranking and headline snippets. Also: the "~1–2s per launch" comment at `pglite.ts:26` describes the *old* boot-time `CREATE EXTENSION` + GIN index builds, which an earlier deferral already removed — it is not evidence for the remaining cost.

## Verification

- `npm run test` → 53 files, 420 tests passing
- `npm run build` → exit 0
- `npx eslint` on all changed files → clean

**Not verified — this is why it's a draft.** Nobody has run an actual cold boot. The under-1.5s acceptance target is untested, and the warm-start does not make either underlying cost *smaller* — it starts them earlier so they overlap auth. If the work is genuinely 3–4s you will still wait, just less of it after auth returns.

Next step before this leaves draft: one cold load in dev, read the `[Boot]` line, and one more in a private window (fresh install, no notes) for the irreducible baseline. If `storageMB` is small while `dbWorker` stays slow, the WASM compile is the long pole and §2 can be closed outright.

## Unrelated, noticed in passing

`src/lib/utils.ts` and `src/lib/utils/` both exist, and `@/lib/utils` resolves to the **file**, silently shadowing the directory's `index.ts`. Pre-existing; not touched here, but it will bite again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y33B3FR2DV2xE6viqBTGMf